### PR TITLE
Adding GH Actions and Codespaces support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG VARIANT=1.17-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get remove -y libssl-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"containerEnv": {
 		"GO_OPENSSL_VERSION_OVERRIDE": "1.1.0",
 	},
-	"onCreateCommand": "bash ${containerWorkspaceFolder}/scripts/openssl.bash ${GO_OPENSSL_VERSION_OVERRIDE}",
+	"onCreateCommand": "sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}",
 	"extensions": [
 		"golang.go"
 	]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json.
+
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "1.17-bullseye",
+		}
+	},
+	"containerEnv": {
+		"GO_OPENSSL_VERSION_OVERRIDE": "1.1.0",
+	},
+	"onCreateCommand": "bash ${containerWorkspaceFolder}/scripts/openssl.bash ${GO_OPENSSL_VERSION_OVERRIDE}",
+	"extensions": [
+		"golang.go"
+	]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ jobs:
         go-version: [1.17.x]
         openssl-version-build: [1.0.2, 1.1.0, 1.1.1]
         openssl-version-test: [1.0.2, 1.1.0, 1.1.1]
+        exclude:
+          # The following combinations are still not supported.
+          - openssl-version-build: 1.1.0
+            openssl-version-test: 1.0.2
+          - openssl-version-build: 1.1.1
+            openssl-version-test: 1.0.2
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.17.x]
-        openssl-version-build: [1.0.2u, 1.1.0l, 1.1.1m]
-        openssl-version-test: [1.0.2u, 1.1.0l, 1.1.1m]
+        openssl-version-build: [1.0.2, 1.1.0, 1.1.1]
+        openssl-version-test: [1.0.2, 1.1.0, 1.1.1]
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.17.x]
+        openssl-version-build: [1.0.2u, 1.1.0l, 1.1.1m]
+        openssl-version-test: [1.0.2u, 1.1.0l, 1.1.1m]
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install build tools
+      run: sudo apt-get install -y build-essential
+    - name: Remove libssl-dev
+      run: sudo apt-get remove -y libssl-dev
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install OpenSSL - Build
+      run: sudo bash ./scripts/openssl.bash ${{ matrix.openssl-version-build }}
+    - name: Run Test - Build
+      run: go test -v ./...
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
+    - name: Build Test - Build
+      run: go test -o test -c ./openssl
+      if: ${{ matrix.openssl-version-build != matrix.openssl-version-test }}
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
+    - name: Install OpenSSL - Test
+      run: sudo bash ./scripts/openssl.bash ${{ matrix.openssl-version-test }}
+      if: ${{ matrix.openssl-version-build != matrix.openssl-version-test }}
+    - name: Run Test 2 - Test
+      run: ./test -test.v
+      if: ${{ matrix.openssl-version-build != matrix.openssl-version-test }}
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-test }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install OpenSSL - Build
-      run: sudo bash ./scripts/openssl.bash ${{ matrix.openssl-version-build }}
+      run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-build }}
     - name: Run Test - Build
       run: go test -v ./...
       env:
@@ -38,7 +38,7 @@ jobs:
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Install OpenSSL - Test
-      run: sudo bash ./scripts/openssl.bash ${{ matrix.openssl-version-test }}
+      run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-test }}
       if: ${{ matrix.openssl-version-build != matrix.openssl-version-test }}
     - name: Run Test 2 - Test
       run: ./test -test.v

--- a/scripts/openssl.bash
+++ b/scripts/openssl.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -eux;
+
+version=$1;
+
+case "$version" in
+    "1.0.2")
+        tag="OpenSSL_1_0_2u";
+        sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05";
+        ;;
+    "1.1.0")
+        tag="OpenSSL_1_1_0l";
+        sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d";
+        ;;
+    "1.1.1")
+        tag="OpenSSL_1_1_1m";
+        sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360";
+        ;;
+    "3.0.0")
+        tag="openssl-3.0.1";
+        sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5";
+        ;;
+    *)
+        echo >&2 "error: unsupported OpenSSL version '$version'";
+        exit 1 ;;
+esac;
+
+cd /usr/local/src
+wget -O $tag.tar.gz https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz;
+echo "$sha256 $tag.tar.gz" | sha256sum -c -;
+rm -rf openssl-$tag
+tar -xzf $tag.tar.gz;
+
+rm -rf openssl-$version
+mv openssl-$tag openssl-$version;
+
+cd openssl-$version;
+./config shared;
+make build_libs;
+
+rm -rf /usr/include/openssl
+cp -r -L ./include/openssl /usr/include;
+cp -H ./libcrypto.so /usr/lib/libcrypto.so.${version};

--- a/scripts/openssl.bash
+++ b/scripts/openssl.bash
@@ -3,45 +3,45 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-set -eux;
+set -eux
 
-version=$1;
+version=$1
 
 case "$version" in
     "1.0.2")
-        tag="OpenSSL_1_0_2u";
-        sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05";
+        tag="OpenSSL_1_0_2u"
+        sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
         ;;
     "1.1.0")
-        tag="OpenSSL_1_1_0l";
-        sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d";
+        tag="OpenSSL_1_1_0l"
+        sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d"
         ;;
     "1.1.1")
-        tag="OpenSSL_1_1_1m";
-        sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360";
+        tag="OpenSSL_1_1_1m"
+        sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"
         ;;
     "3.0.0")
         tag="openssl-3.0.1";
-        sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5";
+        sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5"
         ;;
     *)
-        echo >&2 "error: unsupported OpenSSL version '$version'";
+        echo >&2 "error: unsupported OpenSSL version '$version'"
         exit 1 ;;
-esac;
+esac
 
 cd /usr/local/src
-wget -O $tag.tar.gz https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz;
-echo "$sha256 $tag.tar.gz" | sha256sum -c -;
-rm -rf openssl-$tag
-tar -xzf $tag.tar.gz;
+wget -O $tag.tar.gz https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz
+echo "$sha256 $tag.tar.gz" | sha256sum -c -
+rm -rf openssl-$ta
+tar -xzf $tag.tar.gz
 
 rm -rf openssl-$version
-mv openssl-$tag openssl-$version;
+mv openssl-$tag openssl-$version
 
-cd openssl-$version;
-./config shared;
-make build_libs;
+cd openssl-$version
+./config shared
+make build_libs
 
 rm -rf /usr/include/openssl
-cp -r -L ./include/openssl /usr/include;
-cp -H ./libcrypto.so /usr/lib/libcrypto.so.${version};
+cp -r -L ./include/openssl /usr/include
+cp -H ./libcrypto.so /usr/lib/libcrypto.so.${version}

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
@@ -32,7 +32,7 @@ esac
 cd /usr/local/src
 wget -O $tag.tar.gz https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz
 echo "$sha256 $tag.tar.gz" | sha256sum -c -
-rm -rf openssl-$ta
+rm -rf openssl-$tag
 tar -xzf $tag.tar.gz
 
 rm -rf openssl-$version

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -47,8 +47,5 @@ rm -rf /usr/include/crypto
 
 cp -r -L ./include/openssl /usr/include
 # include/crypto only exists in some OpenSSL versions
-if [ -e ./include/crypto ]
-then
-    cp -r -L ./include/crypto /usr/include
-fi
+test -e ./include/crypto && cp -r -L ./include/crypto /usr/include
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -44,6 +44,8 @@ make build_libs
 
 rm -rf /usr/include/openssl
 rm -rf /usr/include/crypto
+
 cp -r -L ./include/openssl /usr/include
-cp -r -L ./include/crypto /usr/include
+# include/crypto only exists in some OpenSSL versions
+if [[-e ./include/crypto]] && cp -r -L ./include/crypto /usr/include
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -20,7 +20,7 @@ case "$version" in
         tag="OpenSSL_1_1_1m"
         sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"
         ;;
-    "3.0.0")
+    "3.0.1")
         tag="openssl-3.0.1";
         sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5"
         ;;

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -30,18 +30,18 @@ case "$version" in
 esac
 
 cd /usr/local/src
-wget -O $tag.tar.gz https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz
+wget -O "$tag.tar.gz" "https://github.com/openssl/openssl/archive/refs/tags/$tag.tar.gz"
 echo "$sha256 $tag.tar.gz" | sha256sum -c -
-rm -rf openssl-$tag
-tar -xzf $tag.tar.gz
+rm -rf "openssl-$tag"
+tar -xzf "$tag.tar.gz"
 
-rm -rf openssl-$version
-mv openssl-$tag openssl-$version
+rm -rf "openssl-$version"
+mv "openssl-$tag" "openssl-$version"
 
-cd openssl-$version
+cd "openssl-$version"
 ./config shared
 make build_libs
 
 rm -rf /usr/include/openssl
 cp -r -L ./include/openssl /usr/include
-cp -H ./libcrypto.so /usr/lib/libcrypto.so.${version}
+cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -47,7 +47,8 @@ rm -rf /usr/include/crypto
 
 cp -r -L ./include/openssl /usr/include
 # include/crypto only exists in some OpenSSL versions
-if [ -e ./include/crypto ] then
+if [ -e ./include/crypto ]
+then
     cp -r -L ./include/crypto /usr/include
 fi
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -47,5 +47,7 @@ rm -rf /usr/include/crypto
 
 cp -r -L ./include/openssl /usr/include
 # include/crypto only exists in some OpenSSL versions
-if [[-e ./include/crypto]] && cp -r -L ./include/crypto /usr/include
+if [ -e ./include/crypto ] then
+    cp -r -L ./include/crypto /usr/include
+fi
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -43,5 +43,7 @@ cd "openssl-$version"
 make build_libs
 
 rm -rf /usr/include/openssl
+rm -rf /usr/include/crypto
 cp -r -L ./include/openssl /usr/include
+cp -r -L ./include/crypto /usr/include
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"


### PR DESCRIPTION
The main goal of this PR is to add an script than can install form source whatever OpenSSL version. This will facilitate developing and testing this repository.

Additionally, I've used this script to add GitHub Codespaces support and also to trigger some jobs in GitHub Actions that tests the repo against different OpenSSL versions, including building the tests with one version and running them with another (aka portable mode).

The GitHub Actions are temporary and will be replaced by AzDO soon.