### PR TITLE
Use EVP APIs everywhere

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ jobs:
         go-version: [1.17.x]
         openssl-version-build: [1.0.2, 1.1.0, 1.1.1]
         openssl-version-test: [1.0.2, 1.1.0, 1.1.1]
-        exclude:
-          # The following combinations are still not supported.
-          - openssl-version-build: 1.1.0
-            openssl-version-test: 1.0.2
-          - openssl-version-build: 1.1.1
-            openssl-version-test: 1.0.2
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/openssl/apibridge_1_1.c
+++ b/openssl/apibridge_1_1.c
@@ -42,37 +42,6 @@ struct rsa_st
     int _ignored5;
     int _ignored6;
 };
-struct evp_md_ctx_st {
-    const void *_ignored0;
-    void *_ignored1;
-    unsigned long _ignored2;
-    void *md_data;
-    void *_ignored3;
-    int (*_ignored4) (void *ctx, const void *data, size_t count);
-};
-struct evp_md_st {
-    int type;
-    int pkey_type;
-    int md_size;
-    unsigned long flags;
-    int (*init) (EVP_MD_CTX *ctx);
-    int (*update) (EVP_MD_CTX *ctx, const void *data, size_t count);
-    int (*final) (EVP_MD_CTX *ctx, unsigned char *md);
-    int (*copy) (EVP_MD_CTX *to, const EVP_MD_CTX *from);
-    int (*cleanup) (EVP_MD_CTX *ctx);
-    /* FIXME: prototype these some day */
-    int (*sign) (int type, const unsigned char *m, unsigned int m_length,
-                 unsigned char *sigret, unsigned int *siglen, void *key);
-    int (*verify) (int type, const unsigned char *m, unsigned int m_length,
-                   const unsigned char *sigbuf, unsigned int siglen,
-                   void *key);
-    int required_pkey_type[5];  /* EVP_PKEY_xxx */
-    int block_size;
-    int ctx_size;               /* how big does the ctx->md_data need to be */
-    /* control function */
-    int (*md_ctrl) (EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
-};
-#define EVP_PKEY_NULL_method    NULL,NULL,{0,0,0,0}
 #endif
 
 void
@@ -83,12 +52,6 @@ local_HMAC_CTX_free(HMAC_CTX* ctx)
         go_openssl_HMAC_CTX_cleanup(ctx);
         free(ctx);
     }
-}
-
-void*
-local_EVP_MD_CTX_md_data(EVP_MD_CTX *ctx)
-{
-    return ctx->md_data;
 }
 
 HMAC_CTX*
@@ -109,58 +72,15 @@ local_HMAC_CTX_reset(HMAC_CTX* ctx) {
     go_openssl_HMAC_CTX_init(ctx);
 }
 
-struct md5_sha1_ctx {
-  MD5_CTX md5;
-  SHA_CTX sha1;
-};
-
-static int
-md5_sha1_init(EVP_MD_CTX *ctx)
+const EVP_MD*
+local_EVP_md5_sha1(void)
 {
-  struct md5_sha1_ctx *mctx = go_openssl_EVP_MD_CTX_md_data(ctx);
-  if (!go_openssl_MD5_Init(&mctx->md5))
-    return 0;
-  return go_openssl_SHA1_Init(&mctx->sha1);
-}
-
-static int md5_sha1_update(EVP_MD_CTX *ctx, const void *data, size_t count)
-{
-  struct md5_sha1_ctx *mctx = go_openssl_EVP_MD_CTX_md_data(ctx);
-  if (!go_openssl_MD5_Update(&mctx->md5, data, count))
-    return 0;
-  return go_openssl_SHA1_Update(&mctx->sha1, data, count);
-}
-
-static int md5_sha1_final(EVP_MD_CTX *ctx, unsigned char *md)
-{
-  struct md5_sha1_ctx *mctx = go_openssl_EVP_MD_CTX_md_data(ctx);
-  if (!go_openssl_MD5_Final(md, &mctx->md5))
-    return 0;
-  return go_openssl_SHA1_Final(md + MD5_DIGEST_LENGTH, &mctx->sha1);
-}
-
-// Change: Removed:
-// static int ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
-
-static const EVP_MD md5_sha1_md = {
-    NID_md5_sha1,
-    NID_md5_sha1,
-    MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH,
-    0,
-    md5_sha1_init,
-    md5_sha1_update,
-    md5_sha1_final,
-    NULL,
-    NULL,
-    EVP_PKEY_NULL_method, // Change: inserted
-    MD5_CBLOCK,
-    sizeof(EVP_MD *) + sizeof(struct md5_sha1_ctx),
-    NULL, // Change: was ctrl
-};
-
-const EVP_MD* local_EVP_md5_sha1(void)
-{
-  return &md5_sha1_md;
+    // MD5SHA1 is not implemented in OpenSSL 1.0.2.
+    // It is implemented in higher versions but without FIPS support.
+    // It is considered a deprecated digest, not approved by FIPS 140-2
+    // and only used in pre-TLS 1.2, so we would rather not support it
+    // if using 1.0.2 than than implement something that is not properly validated.
+    return NULL;
 }
 
 int

--- a/openssl/apibridge_1_1.h
+++ b/openssl/apibridge_1_1.h
@@ -7,7 +7,6 @@
 // Functions based on OpenSSL 1.1 API, used when building against/running with OpenSSL 1.0.x
 
 void local_HMAC_CTX_free(HMAC_CTX * ctx);
-void* local_EVP_MD_CTX_md_data(EVP_MD_CTX *ctx);
 HMAC_CTX* local_HMAC_CTX_new();
 void local_HMAC_CTX_reset(HMAC_CTX *ctx);
 const EVP_MD* local_EVP_md5_sha1(void);

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -99,6 +99,8 @@ func newECKey(curve string, X, Y, D *big.Int) (pkey *C.EVP_PKEY, err error) {
 			}
 			if pkey != nil {
 				C.go_openssl_EVP_PKEY_free(pkey)
+				// pkey is a named return, so in case of error
+				// it have to be cleared before returing.
 				pkey = nil
 			}
 		}

--- a/openssl/evpkey.go
+++ b/openssl/evpkey.go
@@ -15,6 +15,46 @@ import (
 	"unsafe"
 )
 
+// hashToMD converts a hash.Hash implementation from this package
+// to an OpenSSL *C.EVP_MD.
+func hashToMD(h hash.Hash) *C.EVP_MD {
+	switch h.(type) {
+	case *sha1Hash:
+		return C.go_openssl_EVP_sha1()
+	case *sha224Hash:
+		return C.go_openssl_EVP_sha224()
+	case *sha256Hash:
+		return C.go_openssl_EVP_sha256()
+	case *sha384Hash:
+		return C.go_openssl_EVP_sha384()
+	case *sha512Hash:
+		return C.go_openssl_EVP_sha512()
+	}
+	return nil
+}
+
+// cryptoHashToMD converts a crypto.Hash
+// to an OpenSSL *C.EVP_MD.
+func cryptoHashToMD(ch crypto.Hash) *C.EVP_MD {
+	switch ch {
+	case crypto.MD5:
+		return C.go_openssl_EVP_md5()
+	case crypto.MD5SHA1:
+		return C.go_openssl_EVP_md5_sha1()
+	case crypto.SHA1:
+		return C.go_openssl_EVP_sha1()
+	case crypto.SHA224:
+		return C.go_openssl_EVP_sha224()
+	case crypto.SHA256:
+		return C.go_openssl_EVP_sha256()
+	case crypto.SHA384:
+		return C.go_openssl_EVP_sha384()
+	case crypto.SHA512:
+		return C.go_openssl_EVP_sha512()
+	}
+	return nil
+}
+
 func generateEVPPKey(id C.int, bits int, curve string) (*C.EVP_PKEY, error) {
 	if (bits == 0 && curve == "") || (bits != 0 && curve != "") {
 		panic("openssl: incorrect generateEVPPKey parameters")

--- a/openssl/evpkey.go
+++ b/openssl/evpkey.go
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"crypto"
+	"errors"
+	"hash"
+	"unsafe"
+)
+
+func generateEVPPKey(id C.int, bits int, curve string) (*C.EVP_PKEY, error) {
+	if (bits == 0 && curve == "") || (bits != 0 && curve != "") {
+		panic("openssl: incorrect generateEVPPKey parameters")
+	}
+	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(id, nil)
+	if ctx == nil {
+		return nil, newOpenSSLError("EVP_PKEY_CTX_new_id failed")
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	if C.go_openssl_EVP_PKEY_keygen_init(ctx) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_keygen_init failed")
+	}
+	if bits != 0 {
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, C.EVP_PKEY_CTRL_RSA_KEYGEN_BITS, C.int(bits), nil) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	if curve != "" {
+		nid, err := curveNID(curve)
+		if err != nil {
+			return nil, err
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, C.EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, nil) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	var pkey *C.EVP_PKEY
+	if C.go_openssl_EVP_PKEY_keygen(ctx, &pkey) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_keygen failed")
+	}
+	return pkey, nil
+}
+
+type withKeyFunc func(func(*C.EVP_PKEY) C.int) C.int
+type initFunc func(*C.EVP_PKEY_CTX) C.int
+type cryptFunc func(*C.EVP_PKEY_CTX, *C.uint8_t, *C.uint, *C.uint8_t, C.uint) C.int
+
+func setupEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
+	init initFunc) (ctx *C.EVP_PKEY_CTX, err error) {
+	defer func() {
+		if err != nil {
+			if ctx != nil {
+				C.go_openssl_EVP_PKEY_CTX_free(ctx)
+				ctx = nil
+			}
+		}
+	}()
+
+	withKey(func(pkey *C.EVP_PKEY) C.int {
+		ctx = C.go_openssl_EVP_PKEY_CTX_new(pkey, nil)
+		return 1
+	})
+	if ctx == nil {
+		return nil, newOpenSSLError("EVP_PKEY_CTX_new failed")
+	}
+	if init(ctx) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_operation_init failed")
+	}
+	if padding != 0 {
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, -1, C.EVP_PKEY_CTRL_RSA_PADDING, padding, nil) != 1 {
+			return nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	switch padding {
+	case C.RSA_PKCS1_OAEP_PADDING:
+		md := hashToMD(h)
+		if md == nil {
+			return nil, errors.New("crypto/rsa: unsupported hash function")
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, -1, C.EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
+		clabel := (*C.uint8_t)(C.malloc(C.size_t(len(label))))
+		if clabel == nil {
+			return nil, fail("OPENSSL_malloc")
+		}
+		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, -1, C.EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel)) != 1 {
+			return nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
+		}
+	case C.RSA_PKCS1_PSS_PADDING:
+		if saltLen != 0 {
+			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, -1, C.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, C.int(saltLen), nil) != 1 {
+				return nil, newOpenSSLError("EVP_PKEY_set_rsa_pss_saltlen failed")
+			}
+		}
+		md := cryptoHashToMD(ch)
+		if md == nil {
+			return nil, errors.New("crypto/rsa: unsupported hash function")
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, -1, C.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(md)) != 1 {
+			return nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
+		}
+	case C.RSA_PKCS1_PADDING:
+		if ch != 0 {
+			// We support unhashed messages.
+			md := cryptoHashToMD(ch)
+			if md == nil {
+				return nil, errors.New("crypto/rsa: unsupported hash function")
+			}
+			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, -1, C.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(md)) != 1 {
+				return nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
+			}
+		}
+	}
+
+	return ctx, nil
+}
+
+func cryptEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
+	init initFunc, crypt cryptFunc,
+	sig, in []byte) ([]byte, error) {
+
+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
+	if err != nil {
+		return nil, err
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+
+	var out []byte
+	var outLen C.uint
+	if sig == nil {
+		if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
+		}
+		out = make([]byte, outLen)
+	} else {
+		out = sig
+		outLen = C.uint(len(sig))
+	}
+	if crypt(ctx, base(out), &outLen, base(in), C.uint(len(in))) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
+	}
+	return out[:outLen], nil
+}
+
+func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
+	encryptInit := func(ctx *C.EVP_PKEY_CTX) C.int {
+		return C.go_openssl_EVP_PKEY_encrypt_init(ctx)
+	}
+	encrypt := func(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+		return C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
+	}
+	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, nil, msg)
+}
+
+func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
+	decryptInit := func(ctx *C.EVP_PKEY_CTX) C.int {
+		return C.go_openssl_EVP_PKEY_decrypt_init(ctx)
+	}
+	decrypt := func(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+		return C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
+	}
+	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, nil, msg)
+}
+
+func evpSign(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, hashed []byte) ([]byte, error) {
+	signtInit := func(ctx *C.EVP_PKEY_CTX) C.int {
+		return C.go_openssl_EVP_PKEY_sign_init(ctx)
+	}
+	sign := func(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+		return C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen)
+	}
+	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, nil, hashed)
+}
+
+func evpVerify(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, sig, hashed []byte) error {
+	verifyInit := func(ctx *C.EVP_PKEY_CTX) C.int {
+		return C.go_openssl_EVP_PKEY_verify_init(ctx)
+	}
+	verify := func(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+		return C.go_openssl_EVP_PKEY_verify(ctx, out, *outLen, in, inLen)
+	}
+	_, err := cryptEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
+	return err
+}

--- a/openssl/evpkey.go
+++ b/openssl/evpkey.go
@@ -57,7 +57,7 @@ func cryptoHashToMD(ch crypto.Hash) *C.EVP_MD {
 
 func generateEVPPKey(id C.int, bits int, curve string) (*C.EVP_PKEY, error) {
 	if (bits == 0 && curve == "") || (bits != 0 && curve != "") {
-		panic("openssl: incorrect generateEVPPKey parameters")
+		return nil, fail("incorrect generateEVPPKey parameters")
 	}
 	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(id, nil)
 	if ctx == nil {

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -102,10 +102,10 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
 	ctx2 := C.go_openssl_HMAC_CTX_new()
+	defer C.go_openssl_HMAC_CTX_free(ctx2)
 	if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx) == 0 {
 		panic("openssl: HMAC_CTX_copy failed")
 	}
 	C.go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
-	C.go_openssl_HMAC_CTX_free(ctx2)
 	return append(in, h.sum...)
 }

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -64,7 +64,7 @@ func (h *opensslHMAC) Reset() {
 	if C.go_openssl_HMAC_Init_ex(h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md, nil) == 0 {
 		panic("openssl: HMAC_Init failed")
 	}
-	if size := int(C.go_openssl_EVP_MD_get_size(h.md)); size != h.size {
+	if size := C.go_openssl_EVP_MD_get_size(h.md); size != C.size_t(h.size) {
 		println("openssl: HMAC size:", size, "!=", h.size)
 		panic("openssl: HMAC size mismatch")
 	}

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -9,51 +9,10 @@ package openssl
 // #include "goopenssl.h"
 import "C"
 import (
-	"crypto"
 	"hash"
 	"runtime"
 	"unsafe"
 )
-
-// hashToMD converts a hash.Hash implementation from this package
-// to an OpenSSL *C.EVP_MD.
-func hashToMD(h hash.Hash) *C.EVP_MD {
-	switch h.(type) {
-	case *sha1Hash:
-		return C.go_openssl_EVP_sha1()
-	case *sha224Hash:
-		return C.go_openssl_EVP_sha224()
-	case *sha256Hash:
-		return C.go_openssl_EVP_sha256()
-	case *sha384Hash:
-		return C.go_openssl_EVP_sha384()
-	case *sha512Hash:
-		return C.go_openssl_EVP_sha512()
-	}
-	return nil
-}
-
-// cryptoHashToMD converts a crypto.Hash
-// to an OpenSSL *C.EVP_MD.
-func cryptoHashToMD(ch crypto.Hash) *C.EVP_MD {
-	switch ch {
-	case crypto.MD5:
-		return C.go_openssl_EVP_md5()
-	case crypto.MD5SHA1:
-		return C.go_openssl_EVP_md5_sha1()
-	case crypto.SHA1:
-		return C.go_openssl_EVP_sha1()
-	case crypto.SHA224:
-		return C.go_openssl_EVP_sha224()
-	case crypto.SHA256:
-		return C.go_openssl_EVP_sha256()
-	case crypto.SHA384:
-		return C.go_openssl_EVP_sha384()
-	case crypto.SHA512:
-		return C.go_openssl_EVP_sha512()
-	}
-	return nil
-}
 
 // NewHMAC returns a new HMAC using OpenSSL.
 // The function h must return a hash implemented by
@@ -91,25 +50,15 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 }
 
 type opensslHMAC struct {
-	md          *C.EVP_MD
-	ctx         *C.HMAC_CTX
-	ctx2        *C.HMAC_CTX
-	size        int
-	blockSize   int
-	key         []byte
-	sum         []byte
-	needCleanup bool
+	md        *C.EVP_MD
+	ctx       *C.HMAC_CTX
+	size      int
+	blockSize int
+	key       []byte
+	sum       []byte
 }
 
 func (h *opensslHMAC) Reset() {
-	if !h.needCleanup {
-		h.needCleanup = true
-		// Note: Because of the finalizer, any time h.ctx is passed to cgo,
-		// that call must be followed by a call to runtime.KeepAlive(h),
-		// to make sure h is not collected (and finalized) before the cgo
-		// call returns.
-		runtime.SetFinalizer(h, (*opensslHMAC).finalize)
-	}
 	C.go_openssl_HMAC_CTX_reset(h.ctx)
 
 	if C.go_openssl_HMAC_Init_ex(h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md, nil) == 0 {
@@ -129,7 +78,7 @@ func (h *opensslHMAC) finalize() {
 
 func (h *opensslHMAC) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		C.go_openssl_HMAC_Update(h.ctx, (*C.uint8_t)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
+		C.go_openssl_HMAC_Update(h.ctx, base(p), C.size_t(len(p)))
 	}
 	runtime.KeepAlive(h)
 	return len(p), nil
@@ -152,11 +101,11 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	// that Sum has no effect on the underlying stream.
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
-	h.ctx2 = C.go_openssl_HMAC_CTX_new()
-	if C.go_openssl_HMAC_CTX_copy(h.ctx2, h.ctx) == 0 {
-		panic("openssl: HMAC_CTX_copy_ex failed")
+	ctx2 := C.go_openssl_HMAC_CTX_new()
+	if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx) == 0 {
+		panic("openssl: HMAC_CTX_copy failed")
 	}
-	C.go_openssl_HMAC_Final(h.ctx2, (*C.uint8_t)(unsafe.Pointer(&h.sum[0])), nil)
-	C.go_openssl_HMAC_CTX_free(h.ctx2)
+	C.go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
+	C.go_openssl_HMAC_CTX_free(ctx2)
 	return append(in, h.sum...)
 }

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -93,20 +93,3 @@ func bnToBig(bn *C.BIGNUM) *big.Int {
 	n := C.go_openssl_BN_bn2bin(bn, base(raw))
 	return new(big.Int).SetBytes(raw[:n])
 }
-
-func bigToBn(bnp **C.BIGNUM, b *big.Int) bool {
-	if *bnp != nil {
-		C.go_openssl_BN_free(*bnp)
-		*bnp = nil
-	}
-	if b == nil {
-		return true
-	}
-	raw := b.Bytes()
-	bn := C.go_openssl_BN_bin2bn(base(raw), C.size_t(len(raw)), nil)
-	if bn == nil {
-		return false
-	}
-	*bnp = bn
-	return true
-}

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -46,9 +46,6 @@ DEFINEFUNC_110(int, OPENSSL_init_crypto, (uint64_t ops, const void *settings), (
 DEFINEFUNC(int, FIPS_mode, (void), ()) \
 DEFINEFUNC(int, FIPS_mode_set, (int r), (r)) \
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1)) \
-DEFINEFUNC(int, SHA1_Init, (SHA_CTX * arg0), (arg0)) \
-DEFINEFUNC(int, SHA1_Update, (SHA_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, SHA1_Final, (uint8_t * arg0, SHA_CTX *arg1), (arg0, arg1)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (EVP_MD_CTX *ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 DEFINEFUNC(int, EVP_DigestFinal_ex, (EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
@@ -65,10 +62,6 @@ DEFINEFUNC(const EVP_MD *, EVP_sha512, (void), ()) \
 DEFINEFUNC_FALLBACK(const EVP_MD*, EVP_md5_sha1, (void), ()) \
 DEFINEFUNC_RENAMED(int, EVP_MD_get_type, EVP_MD_type, (const EVP_MD *arg0), (arg0)) \
 DEFINEFUNC_RENAMED(size_t, EVP_MD_get_size, EVP_MD_size, (const EVP_MD *arg0), (arg0)) \
-DEFINEFUNC_FALLBACK(void*, EVP_MD_CTX_md_data, (EVP_MD_CTX *ctx), (ctx)) \
-DEFINEFUNC(int, MD5_Init, (MD5_CTX *c), (c)) \
-DEFINEFUNC(int, MD5_Update, (MD5_CTX *c, const void *data, size_t len), (c, data, len)) \
-DEFINEFUNC(int, MD5_Final, (unsigned char *md, MD5_CTX *c), (md, c)) \
 DEFINEFUNC_LEGACY(void, HMAC_CTX_init, (HMAC_CTX * arg0), (arg0)) \
 DEFINEFUNC_LEGACY(void, HMAC_CTX_cleanup, (HMAC_CTX * arg0), (arg0)) \
 DEFINEFUNC(int, HMAC_Init_ex, \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -84,7 +84,6 @@ DEFINEFUNC(int, EVP_CipherUpdate, \
 DEFINEFUNC(BIGNUM *, BN_new, (void), ()) \
 DEFINEFUNC(void, BN_free, (BIGNUM * arg0), (arg0)) \
 DEFINEFUNC(void, BN_clear_free, (BIGNUM * arg0), (arg0)) \
-DEFINEFUNC(int, BN_set_word, (BIGNUM *a, BN_ULONG w), (a, w)) \
 DEFINEFUNC(unsigned int, BN_num_bits, (const BIGNUM *arg0), (arg0)) \
 DEFINEFUNC(BIGNUM *, BN_bin2bn, (const uint8_t *arg0, size_t arg1, BIGNUM *arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC(size_t, BN_bn2bin, (const BIGNUM *arg0, uint8_t *arg1), (arg0, arg1)) \
@@ -114,21 +113,6 @@ DEFINEFUNC(int, ECDSA_verify,  \
     (type, dgst, dgstlen, sig, siglen, eckey)) \
 DEFINEFUNC(RSA *, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (RSA * arg0), (arg0)) \
-DEFINEFUNC(int, RSA_sign, \
-    (int arg0, const uint8_t *arg1, unsigned int arg2, uint8_t *arg3, unsigned int *arg4, RSA *arg5), \
-    (arg0, arg1, arg2, arg3, arg4, arg5)) \
-DEFINEFUNC(int, RSA_verify, \
-    (int arg0, const uint8_t *arg1, unsigned int arg2, const uint8_t *arg3, unsigned int arg4, RSA *arg5), \
-    (arg0, arg1, arg2, arg3, arg4, arg5)) \
-DEFINEFUNC(int, RSA_private_encrypt, \
-    (int flen, uint8_t *from, uint8_t *to, RSA *rsa, int padding), \
-    (flen, from, to, rsa, padding)) \
-DEFINEFUNC(int, RSA_public_decrypt, \
-    (int flen, uint8_t *from, uint8_t *to, RSA *rsa, int padding), \
-    (flen, from, to, rsa, padding)) \
-DEFINEFUNC(int, RSA_generate_key_ex, \
-    (RSA * arg0, int arg1, BIGNUM *arg2, BN_GENCB *arg3), \
-    (arg0, arg1, arg2, arg3)) \
 DEFINEFUNC_FALLBACK(int, RSA_set0_factors, (RSA * rsa, BIGNUM *p, BIGNUM *q), (rsa, p, q)) \
 DEFINEFUNC_FALLBACK(int, RSA_set0_crt_params, \
     (RSA * rsa, BIGNUM *dmp1, BIGNUM *dmp2, BIGNUM *iqmp), \
@@ -141,7 +125,6 @@ DEFINEFUNC_FALLBACK(void, RSA_get0_factors, (const RSA *rsa, const BIGNUM **p, c
 DEFINEFUNC_FALLBACK(void, RSA_get0_key, \
     (const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d), \
     (rsa, n, e, d)) \
-DEFINEFUNC(unsigned int, RSA_size, (const RSA *arg0), (arg0)) \
 DEFINEFUNC(int, EVP_EncryptInit_ex, \
     (EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv), \
     (ctx, type, impl, key, iv)) \
@@ -169,12 +152,18 @@ DEFINEFUNC(const EVP_CIPHER*, EVP_aes_256_gcm, (void), ()) \
 DEFINEFUNC(void, EVP_CIPHER_CTX_free, (EVP_CIPHER_CTX* arg0), (arg0)) \
 DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 DEFINEFUNC(EVP_PKEY *, EVP_PKEY_new, (void), ()) \
+DEFINEFUNC_RENAMED(int, EVP_PKEY_get_size, EVP_PKEY_size, (const EVP_PKEY *pkey), (pkey)) \
 DEFINEFUNC(void, EVP_PKEY_free, (EVP_PKEY * arg0), (arg0)) \
-DEFINEFUNC(int, EVP_PKEY_set1_RSA, (EVP_PKEY * arg0, RSA *arg1), (arg0, arg1)) \
+DEFINEFUNC(EC_KEY *, EVP_PKEY_get1_EC_KEY, (EVP_PKEY *pkey), (pkey)) \
+DEFINEFUNC(RSA *, EVP_PKEY_get1_RSA, (EVP_PKEY *pkey), (pkey)) \
+DEFINEFUNC(int, EVP_PKEY_assign, (EVP_PKEY *pkey, int type, void *key), (pkey, type, key)) \
 DEFINEFUNC(int, EVP_PKEY_verify, \
     (EVP_PKEY_CTX *ctx, const uint8_t *sig, unsigned int siglen, const uint8_t *tbs, unsigned int tbslen), \
     (ctx, sig, siglen, tbs, tbslen)) \
 DEFINEFUNC(EVP_PKEY_CTX *, EVP_PKEY_CTX_new, (EVP_PKEY * arg0, ENGINE *arg1), (arg0, arg1)) \
+DEFINEFUNC(EVP_PKEY_CTX *, EVP_PKEY_CTX_new_id, (int id, ENGINE *e), (id, e)) \
+DEFINEFUNC(int, EVP_PKEY_keygen_init, (EVP_PKEY_CTX *ctx), (ctx)) \
+DEFINEFUNC(int, EVP_PKEY_keygen, (EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey), (ctx, ppkey)) \
 DEFINEFUNC(void, EVP_PKEY_CTX_free, (EVP_PKEY_CTX * arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_CTX_ctrl, \
     (EVP_PKEY_CTX * ctx, int keytype, int optype, int cmd, int p1, void *p2), \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -93,24 +93,13 @@ DEFINEFUNC(void, EC_POINT_free, (EC_POINT * arg0), (arg0)) \
 DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, \
            (const EC_GROUP *arg0, const EC_POINT *arg1, BIGNUM *arg2, BIGNUM *arg3, BN_CTX *arg4), \
            (arg0, arg1, arg2, arg3, arg4)) \
-DEFINEFUNC(int, EC_POINT_set_affine_coordinates_GFp, \
-           (const EC_GROUP *arg0, EC_POINT *arg1, const BIGNUM *arg2, const BIGNUM *arg3, BN_CTX *arg4), \
-           (arg0, arg1, arg2, arg3, arg4)) \
 DEFINEFUNC(EC_KEY *, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
+DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (EC_KEY *key, BIGNUM *x, BIGNUM *y), (key, x, y)) \
 DEFINEFUNC(void, EC_KEY_free, (EC_KEY * arg0), (arg0)) \
 DEFINEFUNC(const EC_GROUP *, EC_KEY_get0_group, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(int, EC_KEY_generate_key, (EC_KEY * arg0), (arg0)) \
 DEFINEFUNC(int, EC_KEY_set_private_key, (EC_KEY * arg0, const BIGNUM *arg1), (arg0, arg1)) \
-DEFINEFUNC(int, EC_KEY_set_public_key, (EC_KEY * arg0, const EC_POINT *arg1), (arg0, arg1)) \
 DEFINEFUNC(const BIGNUM *, EC_KEY_get0_private_key, (const EC_KEY *arg0), (arg0)) \
 DEFINEFUNC(const EC_POINT *, EC_KEY_get0_public_key, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(size_t, ECDSA_size, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(int, ECDSA_sign,  \
-    (int type, const unsigned char *dgst, size_t dgstlen, unsigned char *sig, unsigned int *siglen, EC_KEY *eckey), \
-    (type, dgst, dgstlen, sig, siglen, eckey)) \
-DEFINEFUNC(int, ECDSA_verify,  \
-    (int type, const unsigned char *dgst, size_t dgstlen, const unsigned char *sig, unsigned int siglen, EC_KEY *eckey), \
-    (type, dgst, dgstlen, sig, siglen, eckey)) \
 DEFINEFUNC(RSA *, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (RSA * arg0), (arg0)) \
 DEFINEFUNC_FALLBACK(int, RSA_set0_factors, (RSA * rsa, BIGNUM *p, BIGNUM *q), (rsa, p, q)) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -49,27 +49,22 @@ DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1)) \
 DEFINEFUNC(int, SHA1_Init, (SHA_CTX * arg0), (arg0)) \
 DEFINEFUNC(int, SHA1_Update, (SHA_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC(int, SHA1_Final, (uint8_t * arg0, SHA_CTX *arg1), (arg0, arg1)) \
-DEFINEFUNC(int, SHA224_Init, (SHA256_CTX * arg0), (arg0)) \
-DEFINEFUNC(int, SHA224_Update, (SHA256_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, SHA224_Final, (uint8_t * arg0, SHA256_CTX *arg1), (arg0, arg1)) \
-DEFINEFUNC(int, SHA256_Init, (SHA256_CTX * arg0), (arg0)) \
-DEFINEFUNC(int, SHA256_Update, (SHA256_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, SHA256_Final, (uint8_t * arg0, SHA256_CTX *arg1), (arg0, arg1)) \
-DEFINEFUNC(int, SHA384_Init, (SHA512_CTX * arg0), (arg0)) \
-DEFINEFUNC(int, SHA384_Update, (SHA512_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, SHA384_Final, (uint8_t * arg0, SHA512_CTX *arg1), (arg0, arg1)) \
-DEFINEFUNC(int, SHA512_Init, (SHA512_CTX * arg0), (arg0)) \
-DEFINEFUNC(int, SHA512_Update, (SHA512_CTX * arg0, const void *arg1, size_t arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, SHA512_Final, (uint8_t * arg0, SHA512_CTX *arg1), (arg0, arg1)) \
+DEFINEFUNC(int, EVP_DigestInit_ex, (EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl), (ctx, type, impl)) \
+DEFINEFUNC(int, EVP_DigestUpdate, (EVP_MD_CTX *ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
+DEFINEFUNC(int, EVP_DigestFinal_ex, (EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC_RENAMED(EVP_MD_CTX *, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
+DEFINEFUNC_RENAMED(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (EVP_MD_CTX *ctx), (ctx)) \
+DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (EVP_MD_CTX *out, const EVP_MD_CTX *in), (out, in)) \
+DEFINEFUNC_RENAMED(int, EVP_MD_CTX_reset, EVP_MD_CTX_cleanup, (EVP_MD_CTX *ctx), (ctx)) \
 DEFINEFUNC(const EVP_MD *, EVP_md5, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha1, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha224, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha256, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha384, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha512, (void), ()) \
+DEFINEFUNC_FALLBACK(const EVP_MD*, EVP_md5_sha1, (void), ()) \
 DEFINEFUNC_RENAMED(int, EVP_MD_get_type, EVP_MD_type, (const EVP_MD *arg0), (arg0)) \
 DEFINEFUNC_RENAMED(size_t, EVP_MD_get_size, EVP_MD_size, (const EVP_MD *arg0), (arg0)) \
-DEFINEFUNC_FALLBACK(const EVP_MD*, EVP_md5_sha1, (void), ()) \
 DEFINEFUNC_FALLBACK(void*, EVP_MD_CTX_md_data, (EVP_MD_CTX *ctx), (ctx)) \
 DEFINEFUNC(int, MD5_Init, (MD5_CTX *c), (c)) \
 DEFINEFUNC(int, MD5_Update, (MD5_CTX *c, const void *data, size_t len), (c, data, len)) \

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -196,8 +196,8 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte,
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
 	if pub.withKey(func(pkey *C.EVP_PKEY) C.int {
-		size := int(C.go_openssl_EVP_PKEY_get_size(pkey))
-		if len(sig) < size {
+		size := C.go_openssl_EVP_PKEY_get_size(pkey)
+		if len(sig) < int(size) {
 			return 0
 		}
 		return 1

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -15,7 +15,6 @@ import (
 	"hash"
 	"math/big"
 	"runtime"
-	"strconv"
 	"unsafe"
 )
 
@@ -23,26 +22,15 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) 
 	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
 		return nil, nil, nil, nil, nil, nil, nil, nil, e
 	}
-
-	key := C.go_openssl_RSA_new()
+	pkey, err := generateEVPPKey(C.EVP_PKEY_RSA, bits, "")
+	if err != nil {
+		return bad(err)
+	}
+	defer C.go_openssl_EVP_PKEY_free(pkey)
+	key := C.go_openssl_EVP_PKEY_get1_RSA(pkey)
 	if key == nil {
-		return bad(newOpenSSLError("RSA_new failed"))
+		return bad(newOpenSSLError("EVP_PKEY_get1_RSA failed"))
 	}
-	defer C.go_openssl_RSA_free(key)
-
-	bn := C.go_openssl_BN_new()
-	if bn == nil {
-		return bad(newOpenSSLError("BN_new failed"))
-	}
-	defer C.go_openssl_BN_free(bn)
-
-	if C.go_openssl_BN_set_word(bn, C.RSA_F4) != C.int(1) {
-		return bad(newOpenSSLError("BN_set_word failed"))
-	}
-	if C.go_openssl_RSA_generate_key_ex(key, C.int(bits), bn, nil) != C.int(1) {
-		return bad(newOpenSSLError("RSA_generate_key_ex failed"))
-	}
-
 	var n, e, d, p, q, dp, dq, qinv *C.BIGNUM
 	C.go_openssl_RSA_get0_key(key, &n, &e, &d)
 	C.go_openssl_RSA_get0_factors(key, &p, &q)
@@ -51,8 +39,8 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) 
 }
 
 type PublicKeyRSA struct {
-	// _key MUST NOT be accessed directly. Instead, use the withKey method.
-	_key *C.RSA
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey *C.EVP_PKEY
 }
 
 func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
@@ -64,26 +52,36 @@ func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
 	n = bigToBN(N)
 	e = bigToBN(E)
 	C.go_openssl_RSA_set0_key(key, n, e, nil)
-	k := &PublicKeyRSA{_key: key}
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		C.go_openssl_RSA_free(key)
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		C.go_openssl_RSA_free(key)
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	k := &PublicKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
 	return k, nil
 }
 
 func (k *PublicKeyRSA) finalize() {
-	C.go_openssl_RSA_free(k._key)
+	C.go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyRSA) withKey(f func(*C.RSA) C.int) C.int {
-	// Because of the finalizer, any time _key is passed to cgo, that call must
+func (k *PublicKeyRSA) withKey(f func(*C.EVP_PKEY) C.int) C.int {
+	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
 	defer runtime.KeepAlive(k)
-	return f(k._key)
+	return f(k._pkey)
 }
 
 type PrivateKeyRSA struct {
-	// _key MUST NOT be accessed directly. Instead, use the withKey method.
-	_key *C.RSA
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey *C.EVP_PKEY
 }
 
 func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, error) {
@@ -107,140 +105,51 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, err
 		qinv = bigToBN(Qinv)
 		C.go_openssl_RSA_set0_crt_params(key, dp, dq, qinv)
 	}
-	k := &PrivateKeyRSA{_key: key}
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		C.go_openssl_RSA_free(key)
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		C.go_openssl_RSA_free(key)
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	k := &PrivateKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
 	return k, nil
 }
 
 func (k *PrivateKeyRSA) finalize() {
-	C.go_openssl_RSA_free(k._key)
+	C.go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyRSA) withKey(f func(*C.RSA) C.int) C.int {
-	// Because of the finalizer, any time _key is passed to cgo, that call must
+func (k *PrivateKeyRSA) withKey(f func(*C.EVP_PKEY) C.int) C.int {
+	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
 	defer runtime.KeepAlive(k)
-	return f(k._key)
-}
-
-func setupRSA(withKey func(func(*C.RSA) C.int) C.int,
-	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
-	init func(*C.EVP_PKEY_CTX) C.int) (pkey *C.EVP_PKEY, ctx *C.EVP_PKEY_CTX, err error) {
-	defer func() {
-		if err != nil {
-			if pkey != nil {
-				C.go_openssl_EVP_PKEY_free(pkey)
-				pkey = nil
-			}
-			if ctx != nil {
-				C.go_openssl_EVP_PKEY_CTX_free(ctx)
-				ctx = nil
-			}
-		}
-	}()
-
-	pkey = C.go_openssl_EVP_PKEY_new()
-	if pkey == nil {
-		return nil, nil, newOpenSSLError("EVP_PKEY_new failed")
-	}
-	if withKey(func(key *C.RSA) C.int {
-		return C.go_openssl_EVP_PKEY_set1_RSA(pkey, key)
-	}) == 0 {
-		return nil, nil, fail("EVP_PKEY_set1_RSA")
-	}
-	ctx = C.go_openssl_EVP_PKEY_CTX_new(pkey, nil)
-	if ctx == nil {
-		return nil, nil, newOpenSSLError("EVP_PKEY_CTX_new failed")
-	}
-	if init(ctx) == 0 {
-		return nil, nil, newOpenSSLError("EVP_PKEY_operation_init failed")
-	}
-	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, -1, C.EVP_PKEY_CTRL_RSA_PADDING, padding, nil) == 0 {
-		return nil, nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
-	}
-	if padding == C.RSA_PKCS1_OAEP_PADDING {
-		md := hashToMD(h)
-		if md == nil {
-			return nil, nil, errors.New("crypto/rsa: unsupported hash function")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, C.EVP_PKEY_OP_TYPE_CRYPT, C.EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)) == 0 {
-			return nil, nil, newOpenSSLError("EVP_PKEY_set_rsa_oaep_md failed")
-		}
-		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
-		clabel := (*C.uint8_t)(C.malloc(C.size_t(len(label))))
-		if clabel == nil {
-			return nil, nil, fail("OPENSSL_malloc")
-		}
-		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, C.EVP_PKEY_OP_TYPE_CRYPT, C.EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel)) == 0 {
-			return nil, nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
-		}
-	}
-	if padding == C.RSA_PKCS1_PSS_PADDING {
-		if saltLen != 0 {
-			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.EVP_PKEY_RSA, C.EVP_PKEY_OP_SIGN|C.EVP_PKEY_OP_VERIFY, C.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, C.int(saltLen), nil) == 0 {
-				return nil, nil, newOpenSSLError("EVP_PKEY_set_rsa_pss_saltlen failed")
-			}
-		}
-		md := cryptoHashToMD(ch)
-		if md == nil {
-			return nil, nil, errors.New("crypto/rsa: unsupported hash function")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, C.EVP_PKEY_OP_TYPE_SIG, C.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(md)) == 0 {
-			return nil, nil, newOpenSSLError("go_openssl_EVP_PKEY_CTX_ctrl failed")
-		}
-	}
-
-	return pkey, ctx, nil
-}
-
-func cryptRSA(withKey func(func(*C.RSA) C.int) C.int,
-	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
-	init func(*C.EVP_PKEY_CTX) C.int,
-	crypt func(*C.EVP_PKEY_CTX, *C.uint8_t, *C.uint, *C.uint8_t, C.uint) C.int,
-	out, in []byte) ([]byte, error) {
-
-	pkey, ctx, err := setupRSA(withKey, padding, h, label, saltLen, ch, init)
-	if err != nil {
-		return nil, err
-	}
-	defer C.go_openssl_EVP_PKEY_free(pkey)
-	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
-
-	var outLen C.uint
-	if out == nil {
-		if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) == 0 {
-			return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
-		}
-		out = make([]byte, outLen)
-	} else {
-		outLen = C.uint(len(out))
-	}
-	if crypt(ctx, base(out), &outLen, base(in), C.uint(len(in))) <= 0 {
-		return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
-	}
-	return out[:outLen], nil
+	return f(k._pkey)
 }
 
 func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-	return cryptRSA(priv.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, decryptInit, decrypt, nil, ciphertext)
+	return evpDecrypt(priv.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, ciphertext)
 }
 
 func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
-	return cryptRSA(pub.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, encryptInit, encrypt, nil, msg)
+	return evpEncrypt(pub.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, msg)
 }
 
 func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-	return cryptRSA(priv.withKey, C.RSA_PKCS1_PADDING, nil, nil, 0, 0, decryptInit, decrypt, nil, ciphertext)
+	return evpDecrypt(priv.withKey, C.RSA_PKCS1_PADDING, nil, nil, ciphertext)
 }
 
 func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-	return cryptRSA(pub.withKey, C.RSA_PKCS1_PADDING, nil, nil, 0, 0, encryptInit, encrypt, nil, msg)
+	return evpEncrypt(pub.withKey, C.RSA_PKCS1_PADDING, nil, nil, msg)
 }
 
 func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-	ret, err := cryptRSA(priv.withKey, C.RSA_NO_PADDING, nil, nil, 0, 0, decryptInit, decrypt, nil, ciphertext)
+	ret, err := evpDecrypt(priv.withKey, C.RSA_NO_PADDING, nil, nil, ciphertext)
 	if err != nil {
 		return nil, err
 	}
@@ -249,15 +158,8 @@ func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error)
 	//
 	// The following code tries to replicate the verification implemented in the upstream function decryptAndCheck, found at
 	// https://github.com/golang/go/blob/9de1ac6ac2cad3871760d0aa288f5ca713afd0a6/src/crypto/rsa/rsa.go#L569-L582.
-	var n, e, d *C.BIGNUM
-	priv.withKey(func(key *C.RSA) C.int {
-		C.go_openssl_RSA_get0_key(key, &n, &e, &d)
-		return 1
-	})
-	pub, err := NewPublicKeyRSA(bnToBig(n), bnToBig(e))
-	if err != nil {
-		return nil, err
-	}
+	pub := &PublicKeyRSA{_pkey: priv._pkey}
+	// A private EVP_PKEY can be used as a public key as it contains the public information.
 	enc, err := EncryptRSANoPadding(pub, ret)
 	if err != nil {
 		return nil, err
@@ -271,95 +173,30 @@ func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error)
 }
 
 func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-	return cryptRSA(pub.withKey, C.RSA_NO_PADDING, nil, nil, 0, 0, encryptInit, encrypt, nil, msg)
-}
-
-// These dumb wrappers work around the fact that cgo functions cannot be used as values directly.
-
-func decryptInit(ctx *C.EVP_PKEY_CTX) C.int {
-	return C.go_openssl_EVP_PKEY_decrypt_init(ctx)
-}
-
-func decrypt(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
-	return C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
-}
-
-func encryptInit(ctx *C.EVP_PKEY_CTX) C.int {
-	return C.go_openssl_EVP_PKEY_encrypt_init(ctx)
-}
-
-func encrypt(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
-	return C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
-}
-
-func signtInit(ctx *C.EVP_PKEY_CTX) C.int {
-	return C.go_openssl_EVP_PKEY_sign_init(ctx)
-}
-
-func sign(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
-	return C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen)
-}
-
-func verifyInit(ctx *C.EVP_PKEY_CTX) C.int {
-	return C.go_openssl_EVP_PKEY_verify_init(ctx)
-}
-
-func verify(ctx *C.EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
-	return C.go_openssl_EVP_PKEY_verify(ctx, out, *outLen, in, inLen)
+	return evpEncrypt(pub.withKey, C.RSA_NO_PADDING, nil, nil, msg)
 }
 
 func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
 	if saltLen == 0 {
 		saltLen = -1 // RSA_PSS_SALTLEN_DIGEST
 	}
-	return cryptRSA(priv.withKey, C.RSA_PKCS1_PSS_PADDING, nil, nil, saltLen, h, signtInit, sign, nil, hashed)
+	return evpSign(priv.withKey, C.RSA_PKCS1_PSS_PADDING, saltLen, h, hashed)
 }
 
 func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 	if saltLen == 0 {
 		saltLen = -2 // RSA_PSS_SALTLEN_AUTO
 	}
-	_, err := cryptRSA(pub.withKey, C.RSA_PKCS1_PSS_PADDING, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
-	return err
+	return evpVerify(pub.withKey, C.RSA_PKCS1_PSS_PADDING, saltLen, h, sig, hashed)
 }
 
 func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
-	if h == 0 {
-		// No hashing.
-		var out []byte
-		var outLen C.int
-		if priv.withKey(func(key *C.RSA) C.int {
-			out = make([]byte, C.go_openssl_RSA_size(key))
-			outLen = C.go_openssl_RSA_private_encrypt(C.int(len(hashed)), base(hashed),
-				base(out), key, C.RSA_PKCS1_PADDING)
-			return outLen
-		}) <= 0 {
-			return nil, newOpenSSLError("RSA_private_encrypt")
-		}
-		return out[:outLen], nil
-	}
-
-	md := cryptoHashToMD(h)
-	if md == nil {
-		return nil, errors.New("crypto/rsa: unsupported hash function: " + strconv.Itoa(int(h)))
-	}
-
-	nid := C.go_openssl_EVP_MD_get_type(md)
-	var out []byte
-	var outLen C.uint
-	if priv.withKey(func(key *C.RSA) C.int {
-		out = make([]byte, C.go_openssl_RSA_size(key))
-		return C.go_openssl_RSA_sign(nid, base(hashed), C.uint(len(hashed)),
-			base(out), &outLen, key)
-	}) == 0 {
-		return nil, newOpenSSLError("RSA_sign")
-	}
-	return out[:outLen], nil
+	return evpSign(priv.withKey, C.RSA_PKCS1_PADDING, 0, h, hashed)
 }
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
-	if pub.withKey(func(key *C.RSA) C.int {
-		size := int(C.go_openssl_RSA_size(key))
+	if pub.withKey(func(pkey *C.EVP_PKEY) C.int {
+		size := int(C.go_openssl_EVP_PKEY_get_size(pkey))
 		if len(sig) < size {
 			return 0
 		}
@@ -367,31 +204,5 @@ func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) err
 	}) == 0 {
 		return errors.New("crypto/rsa: verification error")
 	}
-	if h == 0 {
-		var out []byte
-		var outLen C.int
-		if pub.withKey(func(key *C.RSA) C.int {
-			out = make([]byte, C.go_openssl_RSA_size(key))
-			outLen = C.go_openssl_RSA_public_decrypt(C.int(len(sig)), base(sig), base(out), key, C.RSA_PKCS1_PADDING)
-			return outLen
-		}) <= 0 {
-			return newOpenSSLError("RSA_verify")
-		}
-		if subtle.ConstantTimeCompare(hashed, out[:outLen]) != 1 {
-			return fail("RSA_verify")
-		}
-		return nil
-	}
-	md := cryptoHashToMD(h)
-	if md == nil {
-		return errors.New("crypto/rsa: unsupported hash function")
-	}
-	nid := C.go_openssl_EVP_MD_get_type(md)
-	if pub.withKey(func(key *C.RSA) C.int {
-		return C.go_openssl_RSA_verify(nid, base(hashed), C.uint(len(hashed)),
-			base(sig), C.uint(len(sig)), key)
-	}) == 0 {
-		return newOpenSSLError("RSA_verify failed")
-	}
-	return nil
+	return evpVerify(pub.withKey, C.RSA_PKCS1_PADDING, 0, h, sig, hashed)
 }

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -114,15 +114,15 @@ func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
 }
 
 func TestSignVerifyRSAPSS(t *testing.T) {
-	sha1 := NewSHA1()
+	sha256 := NewSHA256()
 	priv, pub := newRSAKey(t, 2048)
-	sha1.Write([]byte("testing"))
-	hashed := sha1.Sum(nil)
-	signed, err := SignRSAPSS(priv, crypto.SHA1, hashed, 0)
+	sha256.Write([]byte("testing"))
+	hashed := sha256.Sum(nil)
+	signed, err := SignRSAPSS(priv, crypto.SHA256, hashed, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VerifyRSAPSS(pub, crypto.SHA1, hashed, signed, 0)
+	err = VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -9,21 +9,129 @@ package openssl
 // #include "goopenssl.h"
 import "C"
 import (
+	"crypto"
 	"errors"
 	"hash"
+	"runtime"
+	"strconv"
 	"unsafe"
 )
 
-// NewSHA1 returns a new SHA1 hash.
-func NewSHA1() hash.Hash {
-	h := new(sha1Hash)
+type evpHash struct {
+	md  *C.EVP_MD
+	ctx *C.EVP_MD_CTX
+	// ctx2 is used in evpHash.sum to avoid changing
+	// the state of ctx. Having it here allows reusing the
+	// same allocated object multiple times.
+	ctx2      *C.EVP_MD_CTX
+	size      int
+	blockSize int
+}
+
+func newEvpHash(ch crypto.Hash, size, blockSize int) *evpHash {
+	md := cryptoHashToMD(ch)
+	if md == nil {
+		panic("openssl: unsupported hash function: " + strconv.Itoa(int(ch)))
+	}
+	ctx := C.go_openssl_EVP_MD_CTX_new()
+	ctx2 := C.go_openssl_EVP_MD_CTX_new()
+	h := &evpHash{
+		md:        md,
+		ctx:       ctx,
+		ctx2:      ctx2,
+		size:      size,
+		blockSize: blockSize,
+	}
+	runtime.SetFinalizer(h, (*evpHash).finalize)
 	h.Reset()
 	return h
 }
 
+func (h *evpHash) finalize() {
+	C.go_openssl_EVP_MD_CTX_free(h.ctx)
+	C.go_openssl_EVP_MD_CTX_free(h.ctx2)
+}
+
+func (h *evpHash) Reset() {
+	// There is no need to reset h.ctx2 because it is always reset after
+	// use in evpHash.sum.
+	C.go_openssl_EVP_MD_CTX_reset(h.ctx)
+
+	if C.go_openssl_EVP_DigestInit_ex(h.ctx, h.md, nil) != 1 {
+		panic("openssl: EVP_DigestInit_ex failed")
+	}
+	runtime.KeepAlive(h)
+}
+
+func (h *evpHash) Write(p []byte) (int, error) {
+	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) != 1 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	runtime.KeepAlive(h)
+	return len(p), nil
+}
+
+func (h *evpHash) Size() int {
+	return h.size
+}
+
+func (h *evpHash) BlockSize() int {
+	return h.blockSize
+}
+
+func (h *evpHash) sum(out []byte) {
+	// Make copy of context because Go hash.Hash mandates
+	// that Sum has no effect on the underlying stream.
+	// In particular it is OK to Sum, then Write more, then Sum again,
+	// and the second Sum acts as if the first didn't happen.
+	C.go_openssl_EVP_DigestInit_ex(h.ctx2, h.md, nil)
+	if C.go_openssl_EVP_MD_CTX_copy_ex(h.ctx2, h.ctx) != 1 {
+		panic("openssl: EVP_MD_CTX_copy_ex failed")
+	}
+	if C.go_openssl_EVP_DigestFinal_ex(h.ctx2, (*C.uint8_t)(unsafe.Pointer(&out[0])), nil) != 1 {
+		panic("openssl: EVP_DigestFinal_ex failed")
+	}
+	C.go_openssl_EVP_MD_CTX_reset(h.ctx2)
+	runtime.KeepAlive(h)
+}
+
+// shaState returns a pointer to the internal sha structure.
+//
+// The EVP_MD_CTX memory layout has changed in OpenSSL 3
+// and the property holding the internal structure is no longer md_data but algctx.
+func (h *evpHash) shaState() unsafe.Pointer {
+	type mdCtx struct {
+		_       [2]unsafe.Pointer
+		_       C.ulong
+		md_data unsafe.Pointer
+	}
+	if data := (*mdCtx)(unsafe.Pointer(h.ctx)).md_data; data != nil {
+		return data
+	}
+	type algCtx struct {
+		_      [3]unsafe.Pointer
+		_      C.ulong
+		_      [3]unsafe.Pointer
+		algctx unsafe.Pointer
+	}
+	return (*algCtx)(unsafe.Pointer(h.ctx)).algctx
+}
+
+// NewSHA1 returns a new SHA1 hash.
+func NewSHA1() hash.Hash {
+	return &sha1Hash{
+		evpHash: newEvpHash(crypto.SHA1, 20, 64),
+	}
+}
+
 type sha1Hash struct {
-	ctx C.SHA_CTX
+	*evpHash
 	out [20]byte
+}
+
+func (h *sha1Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 type sha1Ctx struct {
@@ -33,33 +141,16 @@ type sha1Ctx struct {
 	nx     uint32
 }
 
-func (h *sha1Hash) Reset()               { C.go_openssl_SHA1_Init(&h.ctx) }
-func (h *sha1Hash) Size() int            { return 20 }
-func (h *sha1Hash) BlockSize() int       { return 64 }
-func (h *sha1Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
-func (h *sha1Hash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_SHA1_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
-		panic("openssl: SHA1_Update failed")
-	}
-	return len(p), nil
-}
-
-func (h0 *sha1Hash) sum() []byte {
-	h := *h0 // make copy so future Write+Sum is valid
-	if C.go_openssl_SHA1_Final((*C.uint8_t)(unsafe.Pointer(&h.out[0])), &h.ctx) == 0 {
-		panic("openssl: SHA1_Final failed")
-	}
-	return h.out[:]
-}
-
 const (
 	sha1Magic         = "sha\x01"
 	sha1MarshaledSize = len(sha1Magic) + 5*4 + 64 + 8
 )
 
 func (h *sha1Hash) MarshalBinary() ([]byte, error) {
-	d := (*sha1Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha1Ctx)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha1: can't retrieve hash state")
+	}
 	b := make([]byte, 0, sha1MarshaledSize)
 	b = append(b, sha1Magic...)
 	b = appendUint32(b, d.h[0])
@@ -80,7 +171,10 @@ func (h *sha1Hash) UnmarshalBinary(b []byte) error {
 	if len(b) != sha1MarshaledSize {
 		return errors.New("crypto/sha1: invalid hash state size")
 	}
-	d := (*sha1Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha1Ctx)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha1: can't retrieve hash state")
+	}
 	b = b[len(sha1Magic):]
 	b, d.h[0] = consumeUint32(b)
 	b, d.h[1] = consumeUint32(b)
@@ -88,7 +182,7 @@ func (h *sha1Hash) UnmarshalBinary(b []byte) error {
 	b, d.h[3] = consumeUint32(b)
 	b, d.h[4] = consumeUint32(b)
 	b = b[copy(d.x[:], b):]
-	b, n := consumeUint64(b)
+	_, n := consumeUint64(b)
 	d.nl = uint32(n << 3)
 	d.nh = uint32(n >> 29)
 	d.nx = uint32(n) % 64
@@ -97,66 +191,36 @@ func (h *sha1Hash) UnmarshalBinary(b []byte) error {
 
 // NewSHA224 returns a new SHA224 hash.
 func NewSHA224() hash.Hash {
-	h := new(sha224Hash)
-	h.Reset()
-	return h
+	return &sha224Hash{
+		evpHash: newEvpHash(crypto.SHA224, 224/8, 64),
+	}
 }
 
 type sha224Hash struct {
-	ctx C.SHA256_CTX
+	*evpHash
 	out [224 / 8]byte
 }
 
-func (h *sha224Hash) Reset()               { C.go_openssl_SHA224_Init(&h.ctx) }
-func (h *sha224Hash) Size() int            { return 224 / 8 }
-func (h *sha224Hash) BlockSize() int       { return 64 }
-func (h *sha224Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
-func (h *sha224Hash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_SHA224_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
-		panic("openssl: SHA224_Update failed")
-	}
-	return len(p), nil
-}
-
-func (h0 *sha224Hash) sum() []byte {
-	h := *h0 // make copy so future Write+Sum is valid
-	if C.go_openssl_SHA224_Final((*C.uint8_t)(unsafe.Pointer(&h.out[0])), &h.ctx) == 0 {
-		panic("openssl: SHA224_Final failed")
-	}
-	return h.out[:]
+func (h *sha224Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 // NewSHA256 returns a new SHA256 hash.
 func NewSHA256() hash.Hash {
-	h := new(sha256Hash)
-	h.Reset()
-	return h
+	return &sha256Hash{
+		evpHash: newEvpHash(crypto.SHA256, 256/8, 64),
+	}
 }
 
 type sha256Hash struct {
-	ctx C.SHA256_CTX
+	*evpHash
 	out [256 / 8]byte
 }
 
-func (h *sha256Hash) Reset()               { C.go_openssl_SHA256_Init(&h.ctx) }
-func (h *sha256Hash) Size() int            { return 256 / 8 }
-func (h *sha256Hash) BlockSize() int       { return 64 }
-func (h *sha256Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
-func (h *sha256Hash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_SHA256_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
-		panic("openssl: SHA256_Update failed")
-	}
-	return len(p), nil
-}
-
-func (h0 *sha256Hash) sum() []byte {
-	h := *h0 // make copy so future Write+Sum is valid
-	if C.go_openssl_SHA256_Final((*C.uint8_t)(unsafe.Pointer(&h.out[0])), &h.ctx) == 0 {
-		panic("openssl: SHA256_Final failed")
-	}
-	return h.out[:]
+func (h *sha256Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 const (
@@ -173,7 +237,10 @@ type sha256Ctx struct {
 }
 
 func (h *sha224Hash) MarshalBinary() ([]byte, error) {
-	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha256Ctx)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
+	}
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic224...)
 	b = appendUint32(b, d.h[0])
@@ -191,7 +258,10 @@ func (h *sha224Hash) MarshalBinary() ([]byte, error) {
 }
 
 func (h *sha256Hash) MarshalBinary() ([]byte, error) {
-	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha256Ctx)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
+	}
 	b := make([]byte, 0, marshaledSize256)
 	b = append(b, magic256...)
 	b = appendUint32(b, d.h[0])
@@ -215,7 +285,10 @@ func (h *sha224Hash) UnmarshalBinary(b []byte) error {
 	if len(b) != marshaledSize256 {
 		return errors.New("crypto/sha256: invalid hash state size")
 	}
-	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha256Ctx)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha256: can't retrieve hash state")
+	}
 	b = b[len(magic224):]
 	b, d.h[0] = consumeUint32(b)
 	b, d.h[1] = consumeUint32(b)
@@ -226,7 +299,7 @@ func (h *sha224Hash) UnmarshalBinary(b []byte) error {
 	b, d.h[6] = consumeUint32(b)
 	b, d.h[7] = consumeUint32(b)
 	b = b[copy(d.x[:], b):]
-	b, n := consumeUint64(b)
+	_, n := consumeUint64(b)
 	d.nl = uint32(n << 3)
 	d.nh = uint32(n >> 29)
 	d.nx = uint32(n) % 64
@@ -240,7 +313,10 @@ func (h *sha256Hash) UnmarshalBinary(b []byte) error {
 	if len(b) != marshaledSize256 {
 		return errors.New("crypto/sha256: invalid hash state size")
 	}
-	d := (*sha256Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha256Ctx)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha256: can't retrieve hash state")
+	}
 	b = b[len(magic256):]
 	b, d.h[0] = consumeUint32(b)
 	b, d.h[1] = consumeUint32(b)
@@ -251,7 +327,7 @@ func (h *sha256Hash) UnmarshalBinary(b []byte) error {
 	b, d.h[6] = consumeUint32(b)
 	b, d.h[7] = consumeUint32(b)
 	b = b[copy(d.x[:], b):]
-	b, n := consumeUint64(b)
+	_, n := consumeUint64(b)
 	d.nl = uint32(n << 3)
 	d.nh = uint32(n >> 29)
 	d.nx = uint32(n) % 64
@@ -260,66 +336,36 @@ func (h *sha256Hash) UnmarshalBinary(b []byte) error {
 
 // NewSHA384 returns a new SHA384 hash.
 func NewSHA384() hash.Hash {
-	h := new(sha384Hash)
-	h.Reset()
-	return h
+	return &sha384Hash{
+		evpHash: newEvpHash(crypto.SHA384, 384/8, 128),
+	}
 }
 
 type sha384Hash struct {
-	ctx C.SHA512_CTX
+	*evpHash
 	out [384 / 8]byte
 }
 
-func (h *sha384Hash) Reset()               { C.go_openssl_SHA384_Init(&h.ctx) }
-func (h *sha384Hash) Size() int            { return 384 / 8 }
-func (h *sha384Hash) BlockSize() int       { return 128 }
-func (h *sha384Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
-func (h *sha384Hash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_SHA384_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
-		panic("openssl: SHA384_Update failed")
-	}
-	return len(p), nil
-}
-
-func (h0 *sha384Hash) sum() []byte {
-	h := *h0 // make copy so future Write+Sum is valid
-	if C.go_openssl_SHA384_Final((*C.uint8_t)(unsafe.Pointer(&h.out[0])), &h.ctx) == 0 {
-		panic("openssl: SHA384_Final failed")
-	}
-	return h.out[:]
+func (h *sha384Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 // NewSHA512 returns a new SHA512 hash.
 func NewSHA512() hash.Hash {
-	h := new(sha512Hash)
-	h.Reset()
-	return h
+	return &sha512Hash{
+		evpHash: newEvpHash(crypto.SHA512, 512/8, 128),
+	}
 }
 
 type sha512Hash struct {
-	ctx C.SHA512_CTX
+	*evpHash
 	out [512 / 8]byte
 }
 
-func (h *sha512Hash) Reset()               { C.go_openssl_SHA512_Init(&h.ctx) }
-func (h *sha512Hash) Size() int            { return 512 / 8 }
-func (h *sha512Hash) BlockSize() int       { return 128 }
-func (h *sha512Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
-func (h *sha512Hash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_SHA512_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
-		panic("openssl: SHA512_Update failed")
-	}
-	return len(p), nil
-}
-
-func (h0 *sha512Hash) sum() []byte {
-	h := *h0 // make copy so future Write+Sum is valid
-	if C.go_openssl_SHA512_Final((*C.uint8_t)(unsafe.Pointer(&h.out[0])), &h.ctx) == 0 {
-		panic("openssl: SHA512_Final failed")
-	}
-	return h.out[:]
+func (h *sha512Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 type sha512Ctx struct {
@@ -340,7 +386,10 @@ const (
 var zero [128]byte
 
 func (h *sha384Hash) MarshalBinary() ([]byte, error) {
-	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha512Ctx)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
+	}
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic384...)
 	b = appendUint64(b, d.h[0])
@@ -358,7 +407,10 @@ func (h *sha384Hash) MarshalBinary() ([]byte, error) {
 }
 
 func (h *sha512Hash) MarshalBinary() ([]byte, error) {
-	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha512Ctx)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
+	}
 	b := make([]byte, 0, marshaledSize512)
 	b = append(b, magic512...)
 	b = appendUint64(b, d.h[0])
@@ -385,7 +437,10 @@ func (h *sha384Hash) UnmarshalBinary(b []byte) error {
 	if len(b) != marshaledSize512 {
 		return errors.New("crypto/sha512: invalid hash state size")
 	}
-	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha512Ctx)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha512: can't retrieve hash state")
+	}
 	b = b[len(magic512):]
 	b, d.h[0] = consumeUint64(b)
 	b, d.h[1] = consumeUint64(b)
@@ -396,7 +451,7 @@ func (h *sha384Hash) UnmarshalBinary(b []byte) error {
 	b, d.h[6] = consumeUint64(b)
 	b, d.h[7] = consumeUint64(b)
 	b = b[copy(d.x[:], b):]
-	b, n := consumeUint64(b)
+	_, n := consumeUint64(b)
 	d.nl = n << 3
 	d.nh = n >> 61
 	d.nx = uint32(n) % 128
@@ -413,7 +468,10 @@ func (h *sha512Hash) UnmarshalBinary(b []byte) error {
 	if len(b) != marshaledSize512 {
 		return errors.New("crypto/sha512: invalid hash state size")
 	}
-	d := (*sha512Ctx)(unsafe.Pointer(&h.ctx))
+	d := (*sha512Ctx)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha512: can't retrieve hash state")
+	}
 	b = b[len(magic512):]
 	b, d.h[0] = consumeUint64(b)
 	b, d.h[1] = consumeUint64(b)
@@ -424,7 +482,7 @@ func (h *sha512Hash) UnmarshalBinary(b []byte) error {
 	b, d.h[6] = consumeUint64(b)
 	b, d.h[7] = consumeUint64(b)
 	b = b[copy(d.x[:], b):]
-	b, n := consumeUint64(b)
+	_, n := consumeUint64(b)
 	d.nl = n << 3
 	d.nh = n >> 61
 	d.nx = uint32(n) % 128


### PR DESCRIPTION
OpenSSL has historically provided two sets of APIs for invoking cryptographic algorithms: the "high level" APIs (such as the `EVP` APIs) and the "low level" APIs.

This PR ports all remaining low level APIs to the EVP APIs that are available since OpenSSL 1.0.2.

This change is important for two reasons:

- The low level APIs were designed in OpenSSL 0.x and do not implement many security checks that do exist in the EVP APIs. More specifically, the FIPS module is only guaranteed to by used if using the EVP interface: https://github.com/openssl/openssl/blob/master/doc/man7/migration_guide.pod#providers-and-fips-support

- Use of the low level APIs has been informally discouraged by the OpenSSL development team for a long time. However in OpenSSL 3.0 this is made more formal,  all such low level APIs have been deprecated.

Tip for reviewers: Review commit by commit instead of the full PR at once. 