### PR TITLE
Support FIPS() and SetFIPS() in OpenSSL 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.17.x]
-        openssl-version-build: [1.0.2, 1.1.0, 1.1.1]
-        openssl-version-test: [1.0.2, 1.1.0, 1.1.1]
+        openssl-version-build: [1.0.2, 1.1.0, 1.1.1, 3.0.1]
+        openssl-version-test: [1.0.2, 1.1.0, 1.1.1, 3.0.1]
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ On the other hand, Google maintains a branch that uses cgo and BoringSSL to impl
 
 ### Multiple OpenSSL versions supported
 
-OpenSSL does not maintain ABI compatibility between different releases, even if only the last digit is increased. The `openssl` package has support for multiple OpenSSL versions, yet each version has a different amount of automated validation:
+The `openssl` package has support for multiple OpenSSL versions, namely 1.0.1, 1.1.0, 1.1.1 and 3.0.2.
 
-- OpenSSL 1.1.1: the Microsoft CI builds official releases and runs automated tests with this version.
-- OpenSSL 1.0.1: the Microsoft CI builds official releases, but doesn't run tests, so it may not produce working applications.
-- OpenSSL 1.1.0 and 3.0: the Microsoft CI does not build nor test these versions, so they may or may not work.
+All supported OpenSSL versions passes an small set of automatic tests that ensure they can be built and that there are no major regressions.
+These tests do not validate the cryptographic correctness of the `openssl` package.
+
+On top of that, the Microsoft CI builds and tests a subset of the supported OpenSSL versions as part of the [Microsoft Go fork](https://github.com/microsoft/go) release process.
+These tests are much more exhaustive and validate an specific OpenSSL version can produce working applications.
+Currently only OpenSSL 1.1.1 is goes through this process.
 
 Versions not listed above are not supported at all.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ All supported OpenSSL versions passes an small set of automatic tests that ensur
 These tests do not validate the cryptographic correctness of the `openssl` package.
 
 On top of that, the Microsoft CI builds and tests a subset of the supported OpenSSL versions as part of the [Microsoft Go fork](https://github.com/microsoft/go) release process.
-These tests are much more exhaustive and validate an specific OpenSSL version can produce working applications.
-Currently only OpenSSL 1.1.1 is goes through this process.
+These tests are much more exhaustive and validate a specific OpenSSL version can produce working applications.
+Currently only OpenSSL 1.1.1 goes through this process.
 
 Versions not listed above are not supported at all.
 

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -16,6 +16,7 @@
 #define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)       DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_3_0(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_FALLBACK(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
 
@@ -25,6 +26,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 
@@ -61,6 +63,11 @@ go_openssl_load_functions(const void* v1_0_sentinel, const void* v1_sentinel)
     {                                                 \
         DEFINEFUNC(ret, func, args, argscall) \
     }
+#define DEFINEFUNC_3_0(ret, func, args, argscall)     \
+    if (v1_sentinel == NULL)                        \
+    {                                                 \
+        DEFINEFUNC(ret, func, args, argscall) \
+    }
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall)                                              \
     tmp_ptr = dlsym(handle, #func);                                                                         \
     if (tmp_ptr == NULL)                                                                                    \
@@ -84,6 +91,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 }

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -178,8 +178,8 @@ go_openssl_setup(void)
 	// v1_0_sentinel is only defined up to OpenSSL 1.0.x.
     const void* v1_0_sentinel = dlsym(handle, "EVP_MD_CTX_cleanup");
 	// v1_0_sentinel is only defined up to OpenSSL 1.x.
-    const void* v1_1_sentinel = dlsym(handle, "FIPS_mode");
-    go_openssl_load_functions(v1_0_sentinel, v1_1_sentinel);
+    const void* v1_sentinel = dlsym(handle, "FIPS_mode");
+    go_openssl_load_functions(v1_0_sentinel, v1_sentinel);
     // OPENSSL_init initialize FIPS callbacks and rand generator.
     // no-op from OpenSSL 1.1.1 onwards.
     go_openssl_OPENSSL_init();

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -13,16 +13,18 @@
 // https://github.com/dotnet/runtime/blob/f64246ce08fb7a58221b2b7c8e68f69c02522b0d/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
 
 #define DEFINEFUNC(ret, func, args, argscall)                  ret (*_g_##func)args; 
-#define DEFINEFUNC_LEGACY(ret, func, args, argscall)           DEFINEFUNC(ret, func, args, argscall)
-#define DEFINEFUNC_110(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)       DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_1_1(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_FALLBACK(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
 
 FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
-#undef DEFINEFUNC_LEGACY
-#undef DEFINEFUNC_110
+#undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
+#undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 
@@ -32,7 +34,7 @@ static void* handle = NULL;
 // and assign them to their corresponding function pointer
 // defined in goopenssl.h.
 static void
-go_openssl_load_functions(const void* v1_0_sentinel)
+go_openssl_load_functions(const void* v1_0_sentinel, const void* v1_sentinel)
 {
     // This function could be called concurrently from different Goroutines unless correctly locked.
     // If that happen there could be a race in DEFINEFUNC_RENAMED where the global function pointer is NULL,
@@ -44,12 +46,17 @@ go_openssl_load_functions(const void* v1_0_sentinel)
 #define DEFINEFUNC(ret, func, args, argscall) \
     _g_##func = dlsym(handle, #func);         \
     if (_g_##func == NULL) { fprintf(stderr, "Cannot get required symbol " #func " from libcrypto\n"); abort(); }
-#define DEFINEFUNC_LEGACY(ret, func, args, argscall)  \
+#define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)  \
     if (v1_0_sentinel != NULL)                        \
     {                                                 \
         DEFINEFUNC(ret, func, args, argscall) \
     }
-#define DEFINEFUNC_110(ret, func, args, argscall)     \
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)  \
+    if (v1_sentinel != NULL)                        \
+    {                                                 \
+        DEFINEFUNC(ret, func, args, argscall) \
+    }
+#define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     if (v1_0_sentinel == NULL)                        \
     {                                                 \
         DEFINEFUNC(ret, func, args, argscall) \
@@ -74,8 +81,9 @@ go_openssl_load_functions(const void* v1_0_sentinel)
 FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
-#undef DEFINEFUNC_LEGACY
-#undef DEFINEFUNC_110
+#undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
+#undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 }
@@ -159,9 +167,11 @@ int local_openssl_thread_setup(void);
 int
 go_openssl_setup(void) 
 {
-    // A function defined in libcrypto.so.1.0.x that is not defined in libcrypto.so.1.1.0
+	// v1_0_sentinel is only defined up to OpenSSL 1.0.x.
     const void* v1_0_sentinel = dlsym(handle, "EVP_MD_CTX_cleanup");
-    go_openssl_load_functions(v1_0_sentinel);
+	// v1_0_sentinel is only defined up to OpenSSL 1.x.
+    const void* v1_1_sentinel = dlsym(handle, "FIPS_mode");
+    go_openssl_load_functions(v1_0_sentinel, v1_1_sentinel);
     // OPENSSL_init initialize FIPS callbacks and rand generator.
     // no-op from OpenSSL 1.1.1 onwards.
     go_openssl_OPENSSL_init();

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -175,9 +175,9 @@ int local_openssl_thread_setup(void);
 int
 go_openssl_setup(void) 
 {
-	// v1_0_sentinel is only defined up to OpenSSL 1.0.x.
+    // v1_0_sentinel is only defined up to OpenSSL 1.0.x.
     const void* v1_0_sentinel = dlsym(handle, "EVP_MD_CTX_cleanup");
-	// v1_0_sentinel is only defined up to OpenSSL 1.x.
+    // v1_0_sentinel is only defined up to OpenSSL 1.x.
     const void* v1_sentinel = dlsym(handle, "FIPS_mode");
     go_openssl_load_functions(v1_0_sentinel, v1_sentinel);
     // OPENSSL_init initialize FIPS callbacks and rand generator.

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -11,7 +11,6 @@
 
 #include <openssl/ossl_typ.h>
 #include <openssl/opensslv.h>
-#include <openssl/ssl.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -48,9 +47,11 @@ int go_openssl_setup(void);
     {                                              \
         return _g_##func argscall;                 \
     }
-#define DEFINEFUNC_LEGACY(ret, func, args, argscall)  \
+#define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)  \
     DEFINEFUNC(ret, func, args, argscall)
-#define DEFINEFUNC_110(ret, func, args, argscall)     \
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)  \
+    DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
@@ -60,8 +61,9 @@ int go_openssl_setup(void);
 FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
-#undef DEFINEFUNC_LEGACY
-#undef DEFINEFUNC_110
+#undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
+#undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -53,6 +53,8 @@ int go_openssl_setup(void);
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_3_0(ret, func, args, argscall)     \
+    DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_FALLBACK(ret, func, args, argscall)     \
@@ -64,6 +66,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED
 #undef DEFINEFUNC_FALLBACK
 

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -97,7 +97,7 @@ func SetFIPS(enabled bool) error {
 		pprop = propFipsNo
 		provName = providerNameDefault
 	}
-	// Check if there is any provided that matches pprop.
+	// Check if there is any provider that matches pprop.
 	if !providerAvailable(pprop) {
 		// If not, fallback to provName provider.
 		if C.go_openssl_OSSL_PROVIDER_load(nil, provName) == nil {

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -43,10 +43,10 @@ func Init() error {
 }
 
 // providerAvailable looks through provider's digests
-// checking if there is any that matches the pprog query.
-func providerAvailable(pprog *C.char) bool {
+// checking if there is any that matches the props query.
+func providerAvailable(props *C.char) bool {
 	C.go_openssl_ERR_set_mark()
-	md := C.go_openssl_EVP_MD_fetch(nil, algProve, pprog)
+	md := C.go_openssl_EVP_MD_fetch(nil, algProve, props)
 	C.go_openssl_ERR_pop_to_mark()
 	if md == nil {
 		return false
@@ -89,26 +89,26 @@ func SetFIPS(enabled bool) error {
 		}
 		return nil
 	}
-	var pprop, provName *C.char
+	var props, provName *C.char
 	if enabled {
-		pprop = propFipsYes
+		props = propFipsYes
 		provName = providerNameFips
 	} else {
-		pprop = propFipsNo
+		props = propFipsNo
 		provName = providerNameDefault
 	}
-	// Check if there is any provider that matches pprop.
-	if !providerAvailable(pprop) {
+	// Check if there is any provider that matches props.
+	if !providerAvailable(props) {
 		// If not, fallback to provName provider.
 		if C.go_openssl_OSSL_PROVIDER_load(nil, provName) == nil {
 			return newOpenSSLError("openssl: OSSL_PROVIDER_try_load")
 		}
 		// Make sure we now have a provider available.
-		if !providerAvailable(pprop) {
+		if !providerAvailable(props) {
 			return fail("SetFIPS(" + strconv.FormatBool(enabled) + ") not supported")
 		}
 	}
-	if C.go_openssl_EVP_set_default_properties(nil, pprop) != 1 {
+	if C.go_openssl_EVP_set_default_properties(nil, props) != 1 {
 		return newOpenSSLError("openssl: EVP_set_default_properties")
 	}
 	return nil

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -38,6 +38,8 @@
 // The process will be aborted if neither function can be loaded.
 //
 #define FOR_ALL_OPENSSL_FUNCTIONS \
+DEFINEFUNC(int, ERR_set_mark, (void), ()) \
+DEFINEFUNC(int, ERR_pop_to_mark, (void), ()) \
 DEFINEFUNC(unsigned long, ERR_get_error, (void), ()) \
 DEFINEFUNC(void, ERR_error_string_n, (unsigned long e, unsigned char *buf, size_t len), (e, buf, len)) \
 DEFINEFUNC_RENAMED(const char *, OpenSSL_version, SSLeay_version, (int type), (type)) \
@@ -54,9 +56,7 @@ DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \
 DEFINEFUNC_LEGACY_1(int, FIPS_mode_set, (int r), (r)) \
 DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (void* libctx), (libctx)) \
 DEFINEFUNC_3_0(int, EVP_set_default_properties, (void *libctx, const char *propq), (libctx, propq)) \
-DEFINEFUNC_3_0(void*, OSSL_PROVIDER_try_load, (void* libctx, const char *name, int retain_fallbacks), (libctx, name, retain_fallbacks)) \
 DEFINEFUNC_3_0(void*, OSSL_PROVIDER_load, (void* libctx, const char *name), (libctx, name)) \
-DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (void* libctx, const char *name), (libctx, name)) \
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (EVP_MD_CTX *ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
@@ -72,6 +72,8 @@ DEFINEFUNC(const EVP_MD *, EVP_sha256, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha384, (void), ()) \
 DEFINEFUNC(const EVP_MD *, EVP_sha512, (void), ()) \
 DEFINEFUNC_FALLBACK(const EVP_MD*, EVP_md5_sha1, (void), ()) \
+DEFINEFUNC_3_0(EVP_MD *, EVP_MD_fetch, (void *ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
+DEFINEFUNC_3_0(void, EVP_MD_free, (EVP_MD* md), (md)) \
 DEFINEFUNC_RENAMED(int, EVP_MD_get_type, EVP_MD_type, (const EVP_MD *arg0), (arg0)) \
 DEFINEFUNC_RENAMED(size_t, EVP_MD_get_size, EVP_MD_size, (const EVP_MD *arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (HMAC_CTX * arg0), (arg0)) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -30,6 +30,9 @@
 // DEFINEFUNC_1_1 acts like DEFINEFUNC but only aborts the process if function can't be loaded
 // when using 1.1.0 or higher.
 //
+// DEFINEFUNC_3_0 acts like DEFINEFUNC but only aborts the process if function can't be loaded
+// when using 3.0.0 or higher.
+//
 // DEFINEFUNC_RENAMED acts like DEFINEFUNC but if the function can't be loaded it will try with another
 // function name, as in some version jumps openssl has renamed functions without changing the signature.
 // The process will be aborted if neither function can be loaded.

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -19,11 +19,15 @@
 // the OpenSSL API and do not require special logic.
 // The process will be aborted if the function can't be loaded.
 //
-// DEFINEFUNC_LEGACY acts like DEFINEFUNC but only aborts the process if the function can't be loaded
+// DEFINEFUNC_LEGACY_1_0 acts like DEFINEFUNC but only aborts the process if the function can't be loaded
 // when using 1.0.x. This indicates the function is required when using 1.0.x, but is unused when using later versions.
 // It also might not exist in later versions.
 //
-// DEFINEFUNC_110 acts like DEFINEFUNC but only aborts the process if function can't be loaded
+// DEFINEFUNC_LEGACY_1 acts like DEFINEFUNC but only aborts the process if the function can't be loaded
+// when using 1.x. This indicates the function is required when using 1.x, but is unused when using later versions.
+// It also might not exist in later versions.
+//
+// DEFINEFUNC_1_1 acts like DEFINEFUNC but only aborts the process if function can't be loaded
 // when using 1.1.0 or higher.
 //
 // DEFINEFUNC_RENAMED acts like DEFINEFUNC but if the function can't be loaded it will try with another
@@ -35,14 +39,14 @@ DEFINEFUNC(unsigned long, ERR_get_error, (void), ()) \
 DEFINEFUNC(void, ERR_error_string_n, (unsigned long e, unsigned char *buf, size_t len), (e, buf, len)) \
 DEFINEFUNC_RENAMED(const char *, OpenSSL_version, SSLeay_version, (int type), (type)) \
 DEFINEFUNC(void, OPENSSL_init, (void), ()) \
-DEFINEFUNC_LEGACY(void, ERR_load_crypto_strings, (void), ()) \
-DEFINEFUNC_LEGACY(int, CRYPTO_num_locks, (void), ()) \
-DEFINEFUNC_LEGACY(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function)) \
-DEFINEFUNC_LEGACY(void, CRYPTO_set_locking_callback, \
+DEFINEFUNC_LEGACY_1_0(void, ERR_load_crypto_strings, (void), ()) \
+DEFINEFUNC_LEGACY_1_0(int, CRYPTO_num_locks, (void), ()) \
+DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function)) \
+DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_locking_callback, \
     (void (*locking_function)(int mode, int n, const char *file, int line)),  \
     (locking_function)) \
-DEFINEFUNC_LEGACY(void, OPENSSL_add_all_algorithms_conf, (void), ()) \
-DEFINEFUNC_110(int, OPENSSL_init_crypto, (uint64_t ops, const void *settings), (ops, settings)) \
+DEFINEFUNC_LEGACY_1_0(void, OPENSSL_add_all_algorithms_conf, (void), ()) \
+DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const void *settings), (ops, settings)) \
 DEFINEFUNC(int, FIPS_mode, (void), ()) \
 DEFINEFUNC(int, FIPS_mode_set, (int r), (r)) \
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1)) \
@@ -62,8 +66,8 @@ DEFINEFUNC(const EVP_MD *, EVP_sha512, (void), ()) \
 DEFINEFUNC_FALLBACK(const EVP_MD*, EVP_md5_sha1, (void), ()) \
 DEFINEFUNC_RENAMED(int, EVP_MD_get_type, EVP_MD_type, (const EVP_MD *arg0), (arg0)) \
 DEFINEFUNC_RENAMED(size_t, EVP_MD_get_size, EVP_MD_size, (const EVP_MD *arg0), (arg0)) \
-DEFINEFUNC_LEGACY(void, HMAC_CTX_init, (HMAC_CTX * arg0), (arg0)) \
-DEFINEFUNC_LEGACY(void, HMAC_CTX_cleanup, (HMAC_CTX * arg0), (arg0)) \
+DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (HMAC_CTX * arg0), (arg0)) \
+DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_cleanup, (HMAC_CTX * arg0), (arg0)) \
 DEFINEFUNC(int, HMAC_Init_ex, \
            (HMAC_CTX * arg0, const void *arg1, int arg2, const EVP_MD *arg3, ENGINE *arg4), \
            (arg0, arg1, arg2, arg3, arg4)) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -53,7 +53,7 @@ DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const void *settings), (
 DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \
 DEFINEFUNC_LEGACY_1(int, FIPS_mode_set, (int r), (r)) \
 DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (void* libctx), (libctx)) \
-DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (void* libctx, int enabled), (libctx, enabled)) \
+DEFINEFUNC_3_0(int, EVP_set_default_properties, (void *libctx, const char *propq), (libctx, propq)) \
 DEFINEFUNC_3_0(void*, OSSL_PROVIDER_try_load, (void* libctx, const char *name, int retain_fallbacks), (libctx, name, retain_fallbacks)) \
 DEFINEFUNC_3_0(void*, OSSL_PROVIDER_load, (void* libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (void* libctx, const char *name), (libctx, name)) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -50,8 +50,13 @@ DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_locking_callback, \
     (locking_function)) \
 DEFINEFUNC_LEGACY_1_0(void, OPENSSL_add_all_algorithms_conf, (void), ()) \
 DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const void *settings), (ops, settings)) \
-DEFINEFUNC(int, FIPS_mode, (void), ()) \
-DEFINEFUNC(int, FIPS_mode_set, (int r), (r)) \
+DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \
+DEFINEFUNC_LEGACY_1(int, FIPS_mode_set, (int r), (r)) \
+DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (void* libctx), (libctx)) \
+DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (void* libctx, int enabled), (libctx, enabled)) \
+DEFINEFUNC_3_0(void*, OSSL_PROVIDER_try_load, (void* libctx, const char *name, int retain_fallbacks), (libctx, name, retain_fallbacks)) \
+DEFINEFUNC_3_0(void*, OSSL_PROVIDER_load, (void* libctx, const char *name), (libctx, name)) \
+DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (void* libctx, const char *name), (libctx, name)) \
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (EVP_MD_CTX *ctx, const void *d, size_t cnt), (ctx, d, cnt)) \


### PR DESCRIPTION
OpenSSL 3 removed `FIPS_mode` and `FIPS_mode_set` APIs. These functions are legacy APIs that are not applicable to the new provider model. OpenSSL recommends using `EVP_default_properties_is_fips_enabled` and `EVP_default_properties_enable_fips`.

The problem with the new functions is that they are only setting the intent to use FIPS mode, but they are not checking if there is a provider that implements FIPS. The user could activate a FIPS provider using the OpenSSL config file, but we have tried to avoid using it in the past, so if it is not available we will do our best to load it using `OSSL_PROVIDER_load` and fail if that's not possible.

It implements the following provider fallback logic in SetFIPS():
- The `fips` provider is loaded if `enabled=true` and no loaded provider matches `fips=yes`
- The `default` provider is loaded if `enabled=false` and no loaded provider matches `fips=no`.

This logic allows advanced users to define their own providers that match `fips=yes` and `fips=no` using the OpenSSL config file.

This approach follows several ideas from https://wiki.openssl.org/index.php/OpenSSL_3.0#Using_the_FIPS_Module_in_applications