### PR TITLE
Improve OpenSSL loading

### DIFF
--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -9,6 +9,61 @@
 #include <dlfcn.h>
 #include <stdio.h>
 
+static unsigned long
+version_num(void* handle)
+{
+    unsigned long (*fn)(void);
+    // OPENSSL_version_num is defined in OpenSSL 1.1.0 and 1.1.1.
+    fn = (unsigned long (*)(void))dlsym(handle, "OpenSSL_version_num");
+    if (fn != NULL)
+        return fn();
+
+    // SSLeay is defined in OpenSSL 1.0.2.
+    fn = (unsigned long (*)(void))dlsym(handle, "SSLeay");
+    if (fn != NULL)
+        return fn();
+
+    return 0;
+} 
+
+int
+go_openssl_version_major(void* handle)
+{
+    unsigned int (*fn)(void);
+    // OPENSSL_version_major is supported since OpenSSL 3.
+    fn = (unsigned int (*)(void))dlsym(handle, "OPENSSL_version_major");
+    if (fn != NULL)
+        return (int)fn();
+
+    // If OPENSSL_version_major is not defined, try with OpenSSL 1 functions.
+    unsigned long num = version_num(handle);
+    if (num < 0x10000000L || num >= 0x20000000L)
+        return -1;
+
+    return 1;
+}
+
+int
+go_openssl_version_minor(void* handle)
+{
+    unsigned int (*fn)(void);
+    // OPENSSL_version_major is supported since OpenSSL 3.
+    fn = (unsigned int (*)(void))dlsym(handle, "OPENSSL_version_minor");
+    if (fn != NULL)
+        return (int)fn();
+
+    // If OPENSSL_version_major is not defined, try with OpenSSL 1 functions.
+    unsigned long num = version_num(handle);
+    if (num < 0x10000000L || num >= 0x10200000L)
+        // We only support minor version 0 and 1.
+        return -1;
+
+    if (num >= 0x10100000L)
+        return 1;
+    
+    return 0;
+}
+
 // Approach taken from .Net System.Security.Cryptography.Native
 // https://github.com/dotnet/runtime/blob/f64246ce08fb7a58221b2b7c8e68f69c02522b0d/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
 
@@ -32,8 +87,11 @@ FOR_ALL_OPENSSL_FUNCTIONS
 // and assign them to their corresponding function pointer
 // defined in goopenssl.h.
 void
-go_openssl_load_functions(void* handle, const void* v1_0_sentinel, const void* v1_sentinel)
+go_openssl_load_functions(void* handle)
 {
+    int major = go_openssl_version_major(handle);
+    int minor = go_openssl_version_minor(handle);
+
     // This function could be called concurrently from different Goroutines unless correctly locked.
     // If that happen there could be a race in DEFINEFUNC_RENAMED where the global function pointer is NULL,
     // then properly loaded, then goes back to NULL right before being used (then loaded again).
@@ -45,24 +103,24 @@ go_openssl_load_functions(void* handle, const void* v1_0_sentinel, const void* v
     _g_##func = dlsym(handle, #func);         \
     if (_g_##func == NULL) { fprintf(stderr, "Cannot get required symbol " #func " from libcrypto\n"); abort(); }
 #define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)  \
-    if (v1_0_sentinel != NULL)                        \
-    {                                                 \
-        DEFINEFUNC(ret, func, args, argscall) \
+    if (major == 1 && minor == 0)                         \
+    {                                                     \
+        DEFINEFUNC(ret, func, args, argscall)             \
     }
 #define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)  \
-    if (v1_sentinel != NULL)                        \
-    {                                                 \
-        DEFINEFUNC(ret, func, args, argscall) \
+    if (major == 1)                                     \
+    {                                                   \
+        DEFINEFUNC(ret, func, args, argscall)           \
     }
 #define DEFINEFUNC_1_1(ret, func, args, argscall)     \
-    if (v1_0_sentinel == NULL)                        \
+    if (major == 3 || (major == 1 && minor == 1))     \
     {                                                 \
-        DEFINEFUNC(ret, func, args, argscall) \
+        DEFINEFUNC(ret, func, args, argscall)         \
     }
 #define DEFINEFUNC_3_0(ret, func, args, argscall)     \
-    if (v1_sentinel == NULL)                        \
+    if (major == 3)                                   \
     {                                                 \
-        DEFINEFUNC(ret, func, args, argscall) \
+        DEFINEFUNC(ret, func, args, argscall)         \
     }
 #define DEFINEFUNC_RENAMED(ret, func, oldfunc, args, argscall)                                              \
     tmp_ptr = dlsym(handle, #func);                                                                         \

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -54,8 +54,8 @@ go_openssl_version_minor(void* handle)
 
     // If OPENSSL_version_major is not defined, try with OpenSSL 1 functions.
     unsigned long num = version_num(handle);
+    // We only support minor version 0 and 1.
     if (num < 0x10000000L || num >= 0x10200000L)
-        // We only support minor version 0 and 1.
         return -1;
 
     if (num >= 0x10100000L)

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -54,9 +54,15 @@ go_openssl_version_minor(void* handle)
 
     // If OPENSSL_version_major is not defined, try with OpenSSL 1 functions.
     unsigned long num = version_num(handle);
-    // We only support minor version 0 and 1.
+    // OpenSSL version number follows this schema:
+    // MNNFFPPS: major minor fix patch status.
     if (num < 0x10000000L || num >= 0x10200000L)
+    {
+        // We only support minor version 0 and 1,
+        // so there is no need to implement an algorithm
+        // that decodes the version number into individual components.
         return -1;
+    }
 
     if (num >= 0x10100000L)
         return 1;
@@ -87,11 +93,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 // and assign them to their corresponding function pointer
 // defined in goopenssl.h.
 void
-go_openssl_load_functions(void* handle)
+go_openssl_load_functions(void* handle, int major, int minor)
 {
-    int major = go_openssl_version_major(handle);
-    int minor = go_openssl_version_minor(handle);
-
     // This function could be called concurrently from different Goroutines unless correctly locked.
     // If that happen there could be a race in DEFINEFUNC_RENAMED where the global function pointer is NULL,
     // then properly loaded, then goes back to NULL right before being used (then loaded again).

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -25,8 +25,10 @@
 #include <openssl/ecdsa.h>
 #include <openssl/rsa.h>
 
+int go_openssl_version_major(void* handle);
+int go_openssl_version_minor(void* handle);
 int go_openssl_thread_setup(void);
-void go_openssl_load_functions(void* handle, const void* v1_0_sentinel, const void* v1_sentinel);
+void go_openssl_load_functions(void* handle);
 
 #define GO_OPENSSL_INIT_LOAD_CRYPTO_STRINGS 0x00000002L
 #define GO_OPENSSL_INIT_ADD_ALL_CIPHERS 0x00000004L

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -28,7 +28,7 @@
 int go_openssl_version_major(void* handle);
 int go_openssl_version_minor(void* handle);
 int go_openssl_thread_setup(void);
-void go_openssl_load_functions(void* handle);
+void go_openssl_load_functions(void* handle, int major, int minor);
 
 #define GO_OPENSSL_INIT_LOAD_CRYPTO_STRINGS 0x00000002L
 #define GO_OPENSSL_INIT_ADD_ALL_CIPHERS 0x00000004L

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -113,7 +113,7 @@ func Init() error {
 func dlopen(version string) unsafe.Pointer {
 	cv := C.CString("libcrypto.so." + version)
 	defer C.free(unsafe.Pointer(cv))
-	return C.dlopen(cv, C.RTLD_LAZY|C.RTLD_GLOBAL)
+	return C.dlopen(cv, C.RTLD_LAZY|C.RTLD_LOCAL)
 }
 
 func loadLibrary(version string) (unsafe.Pointer, error) {

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -90,7 +90,7 @@ func Init() error {
 			return
 		}
 
-		C.go_openssl_load_functions(handle)
+		C.go_openssl_load_functions(handle, C.int(vMajor), C.int(vMinor))
 		C.go_openssl_OPENSSL_init()
 		if vMajor == 1 && vMinor == 0 {
 			if C.go_openssl_thread_setup() != 1 {

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -27,8 +27,6 @@ var (
 	propFipsYes         = C.CString("fips=yes")
 	propFipsNo          = C.CString("fips=no")
 	algProve            = C.CString("SHA2-256")
-	sentinelNameV1_0    = C.CString("EVP_MD_CTX_cleanup")
-	sentinelNameV1      = C.CString("FIPS_mode")
 )
 
 var (
@@ -73,24 +71,26 @@ func Init() error {
 			errInit = err
 			return
 		}
-		// v1_0_sentinel is only defined up to and including OpenSSL 1.0.x.
-		v1_0_sentinel := C.dlsym(handle, sentinelNameV1_0)
-		// v1_sentinel is only defined up to and including OpenSSL 1.x.
-		v1_sentinel := C.dlsym(handle, sentinelNameV1)
 
-		C.go_openssl_load_functions(handle, v1_0_sentinel, v1_sentinel)
-
-		if v1_sentinel != nil {
-			vMajor = 1
-			if v1_0_sentinel != nil {
-				vMinor = 0
-			} else {
-				vMinor = 1
-			}
-		} else {
-			vMajor = 3
-			vMinor = 0
+		vMajor = int(C.go_openssl_version_major(handle))
+		vMinor = int(C.go_openssl_version_minor(handle))
+		if vMajor == -1 || vMinor == -1 {
+			errInit = errors.New("openssl: can't retrieve OpenSSL version")
+			return
 		}
+		var supported bool
+		if vMajor == 1 {
+			supported = vMinor == 0 || vMinor == 1
+		} else if vMajor == 3 {
+			// OpenSSL team guarantees API and ABI compatibility within the same major version since OpenSSL 3.
+			supported = true
+		}
+		if !supported {
+			errInit = errUnsuportedVersion()
+			return
+		}
+
+		C.go_openssl_load_functions(handle)
 		C.go_openssl_OPENSSL_init()
 		if vMajor == 1 && vMinor == 0 {
 			if C.go_openssl_thread_setup() != 1 {

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -15,8 +15,9 @@ import (
 func TestMain(m *testing.M) {
 	err := Init()
 	if err != nil {
-		fmt.Println("skipping on linux platform without OpenSSL")
-		os.Exit(0)
+		// An error here could mean that this Linux distro does not have a supported OpenSSL version
+		// or that there is a bug in the Init code.
+		panic(err)
 	}
 	_ = SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
 	fmt.Println("OpenSSL version:", VersionText())


### PR DESCRIPTION
There are several changes in this PR:

1. We no longer infer OpenSSL version from available symbols, as we could infer the wrong version if the Linux distro patches OpenSSL to add or remove upstream symbols.

2. `Init` errors out if the OpenSSL version loaded is not supported. This makes the openssl package more reliable, as the previous behavior was more unpredictable:
    - `Init` would panic if a required symbol can't be loaded, regardless of the OpenSSL version.
    - Most functions would panic if Init succeed but `vMajor` was different than 1 or 3.
Notice that even if we only test OpenSSL 3.0.1, in theory all the OpenSSL 3 series should be supported as the OpenSSL team guarantees API and ABI compatibility within the same major version since OpenSSL 3.

3. Use RTLD_LOCAL instead of RTLD_GLOBAL when loading libcrypto. This avoids polluting the global symbol table and ensures no one depends on symbols we have loaded.

4. Fail tests if `Init` returns an error. We were previously silently skipping all tests.