### PR TITLE
Fix EVP_PKEY_{encrypt,decrypt,sign,verify}, functions

### DIFF
--- a/openssl/evpkey.go
+++ b/openssl/evpkey.go
@@ -97,6 +97,7 @@ func generateEVPPKey(id C.int, bits int, curve string) (C.GO_EVP_PKEY_PTR, error
 type withKeyFunc func(func(C.GO_EVP_PKEY_PTR) C.int) C.int
 type initFunc func(C.GO_EVP_PKEY_CTX_PTR) C.int
 type cryptFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uint8_t, *C.uint, *C.uint8_t, C.uint) C.int
+type verifyFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uint8_t, C.uint, *C.uint8_t, C.uint) C.int
 
 func setupEVP(withKey withKeyFunc, padding C.int,
 	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
@@ -201,30 +202,38 @@ func setupEVP(withKey withKeyFunc, padding C.int,
 
 func cryptEVP(withKey withKeyFunc, padding C.int,
 	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
-	init initFunc, crypt cryptFunc,
-	sig, in []byte) ([]byte, error) {
+	init initFunc, crypt cryptFunc, in []byte) ([]byte, error) {
 
 	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
 	if err != nil {
 		return nil, err
 	}
 	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
-
-	var out []byte
 	var outLen C.uint
-	if sig == nil {
-		if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
-		}
-		out = make([]byte, outLen)
-	} else {
-		out = sig
-		outLen = C.uint(len(sig))
+	if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
 	}
+	out := make([]byte, outLen)
 	if crypt(ctx, base(out), &outLen, base(in), C.uint(len(in))) != 1 {
 		return nil, newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
 	}
 	return out[:outLen], nil
+}
+
+func verifyEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
+	init initFunc, verify verifyFunc,
+	sig, in []byte) error {
+
+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
+	if err != nil {
+		return err
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	if verify(ctx, base(sig), C.uint(len(sig)), base(in), C.uint(len(in))) != 1 {
+		return newOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
+	}
+	return nil
 }
 
 func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
@@ -234,7 +243,7 @@ func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []by
 	encrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
 		return C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
 	}
-	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, nil, msg)
+	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, msg)
 }
 
 func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
@@ -244,7 +253,7 @@ func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []by
 	decrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
 		return C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
 	}
-	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, nil, msg)
+	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, msg)
 }
 
 func evpSign(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, hashed []byte) ([]byte, error) {
@@ -254,16 +263,15 @@ func evpSign(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, has
 	sign := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
 		return C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen)
 	}
-	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, nil, hashed)
+	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, hashed)
 }
 
 func evpVerify(withKey withKeyFunc, padding C.int, saltLen int, h crypto.Hash, sig, hashed []byte) error {
 	verifyInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) C.int {
 		return C.go_openssl_EVP_PKEY_verify_init(ctx)
 	}
-	verify := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
-		return C.go_openssl_EVP_PKEY_verify(ctx, out, *outLen, in, inLen)
+	verify := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uint8_t, outLen C.uint, in *C.uint8_t, inLen C.uint) C.int {
+		return C.go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen)
 	}
-	_, err := cryptEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
-	return err
+	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
 }

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -161,7 +161,7 @@ DEFINEFUNC(EC_KEY *, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(RSA *, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(int, EVP_PKEY_assign, (GO_EVP_PKEY_PTR pkey, int type, void *key), (pkey, type, key)) \
 DEFINEFUNC(int, EVP_PKEY_verify, \
-    (GO_EVP_PKEY_CTX_PTR ctx, const uint8_t *sig, unsigned int siglen, const uint8_t *tbs, unsigned int tbslen), \
+    (GO_EVP_PKEY_CTX_PTR ctx, const uint8_t *sig, size_t siglen, const uint8_t *tbs, size_t tbslen), \
     (ctx, sig, siglen, tbs, tbslen)) \
 DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new, (GO_EVP_PKEY_PTR arg0, ENGINE *arg1), (arg0, arg1)) \
 DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_id, (int id, ENGINE *e), (id, e)) \
@@ -172,15 +172,15 @@ DEFINEFUNC(int, EVP_PKEY_CTX_ctrl, \
     (GO_EVP_PKEY_CTX_PTR ctx, int keytype, int optype, int cmd, int p1, void *p2), \
     (ctx, keytype, optype, cmd, p1, p2)) \
 DEFINEFUNC(int, EVP_PKEY_decrypt, \
-    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4), \
+    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, size_t arg4), \
     (arg0, arg1, arg2, arg3, arg4)) \
 DEFINEFUNC(int, EVP_PKEY_encrypt, \
-    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4), \
+    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, size_t arg4), \
     (arg0, arg1, arg2, arg3, arg4)) \
 DEFINEFUNC(int, EVP_PKEY_decrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign, \
-    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4), \
+    (GO_EVP_PKEY_CTX_PTR arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, size_t arg4), \
     (arg0, arg1, arg2, arg3, arg4))


### PR DESCRIPTION
We have had a latent bug in some of the EVP_PKEY_* functions which has been uncovered by the recent optimization changes. Those functions need to know the length of the provided memory buffers as a `size_t` integer, but we are passing the length as an `unsigned int`.

In theory this shouldn't be a problem, as `uint` is smaller than `size_t` and both are unsigned integers, so no information is lost. The problem could be related to cgo passing all the function call arguments as a single memory chunk, and the memory layout of the function signature using `uint` vs `size_t` is not the same due to the 4 extra bytes of `size_t` (at least in amd64).\

Before finding this issue I was already preparing a script that we will run together with the test that will verify the function signatures and constant values defined in our headers match the OpenSSL definitions for every supported version. This would have catch this bug before entering main. It is not finished yet.

