### PR TITLE
Use all cores when running make build_libs

### DIFF
--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -40,7 +40,7 @@ mv "openssl-$tag" "openssl-$version"
 
 cd "openssl-$version"
 ./config shared
-make build_libs
+make -j$(nproc) build_libs
 
 rm -rf /usr/include/openssl
 rm -rf /usr/include/crypto


### PR DESCRIPTION
Building OpenSSL is slow. Make it faster by using all cores when running `make build_libs`.