### PR TITLE
aes: add GCM-TLS checks and improve performance

### DIFF
--- a/docs/go-openssl-compat.md
+++ b/docs/go-openssl-compat.md
@@ -1,0 +1,87 @@
+# Compatibility of Go BoringCrypto and OpenSSL
+
+## Goal
+
+List implementation decisions taken to smooth out differences between Go BoringCrypto expectations and OpenSSL behavior.
+
+## Background
+
+Go BoringCrypto branch delegates core cryptographic algorithms to BoringSSL. Go does not support pluggable crypto backends, so in order to support BoringSSL, the BoringCrypto branch contains non-trivial modifications to several `crypto` packages. These modifications are not generic abstractions over crypto algorithms as they specifically target BoringSSL compatibility.
+
+The BoringSSL library was forked from OpenSSL 1.0.2 beta, a version that `go-crypto-openssl`supports and that already makes heavy use of the EVP interface. This fact facilitates the translation from BoringSSL to OpenSSL functions. Yet, Go BoringCrypto implements some algorithms using functions that are either deprecated in newer -but supported by us- OpenSSL versions or directly non-existing.
+
+In this situations were there is no direct mapping, we try to combine several OpenSSL functions so the security is not compromised, being the trade-off between speed and maintainability.
+
+## Implementation decisions
+
+### AES-GCM encryption in TLS mode
+
+#### Background
+
+AES-GCM with Additional Data (aka AEAD) is a symmetric block cipher whose text-book encryption inputs are:
+- initialization vector (aka nonce or iv)
+- plaintext
+- additional authenticated data
+
+And the outputs are:
+- ciphertext
+- authentication tag
+
+Go abstracts this algorithm using the `Seal` method in the [cipher.AEAD](https://pkg.go.dev/crypto/cipher#AEAD) interface:
+
+`Seal(dst, nonce, plaintext, additionalData []byte) []byte`
+
+Where dst is just a backing memory buffer to reduce allocations and the returned byte slice is the ciphertext with the authentication tag appended.
+
+When AES-GCM is used to encrypt a TLS payload (aka TLS mode), FIPS 140-2 IG A.5 ["Key/IV Pair Uniqueness * Requirements from SP 800-38D"](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), and the general security consensus, requires constructing the IV parameter deterministically by concatenating two fields:
+- Fixed 4 bytes field which identifies the encryption context and is reused in different Seal operations using the same key.
+- Explicit 8 bytes field which identifies the Seal operation within an encryption context. This field must not be reused in the same encryption context and should be set using a counter incremented in every Seal operation within an encryption context.
+
+As it is implemented in BoringCrypto, Go TLS stack is the one responsible of constructing a valid uniq Key/IV pair, which is passed the `Seal` method (backed by BoringSSL or OpenSSL) with the expectation that the nonce is honored. 
+
+#### BoringSSL
+
+BoringSSL implements the AES-GCM TLS encryption using the [EVP_AEAD_CTX_seal](https://man.openbsd.org/EVP_AEAD_CTX_seal.3) on-shot function, which have a one-to-one mapping with Go's `Seal` method and also enforces that the provided nonce matches the FIPS 140-2 IG A.5 requirements. So BoringSSL honors Go's IV and at the same time ensures it is secure.
+
+#### OpenSSL
+
+OpenSSL does not provide the `EVP_AEAD_CTX_seal` function, so AES-GCM should be implemented using several several EVP_ENCRYPT* functions, as described in [here](https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption). The problem with this recipe is that it does not enforce the additional TLS requirements, it just blindly uses whatever IV is passed.
+
+This is because OpenSSL don't expect that recipe to be used for AES-GCM TLS encryption, but it provided instead a control parameter, EVP_CTRL_AEAD_TLS1_AAD, that when applied to an encryption context it makes it work in TLS-mode and completely change the encryption workflow (more details [here](https://beta.openssl.org/docs/manmaster/man3/EVP_CipherInit_ex.html#tlsivfixed-OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED-octet-string)).
+
+The main difference is that the explicit IV field is no longer managed by the caller but by the OpenSSL encryption context, incrementing it on every Seal operation and applying some additional checks. This means that OpenSSL won't honor the IV constructed by Go, and therefore it will make Go send corrupted packaged to the wire.
+
+#### Assumptions
+
+1. Go constructs IVs that are FIPS 140-2 compliant. BoringCrypto also works under this assumption.
+
+#### Options
+
+1. Use OpenSSL AES-GCM in TLS mode, which means IV construction is secured inside OpenSSL context but Go expectations are not meet, therefore it requires the following changes to Go TLS stack:
+  - In `go-crypto-openssl`, change `NewGCMTLS` to accept the 4 bytes fixed IV field.
+  - In `crypto/tls`:
+    - Define a new AEAD-like interface, i.e. `AEAD2`, whose `Seal` method does not accept an IV and returns a byte slice with iv+ciphertext+tag.
+    - Construct the AES-GCM TLS cipher using the new method.
+    - Don't generate an IV when the cipher implements the AEAD2 interface.
+    - Use the AEAD2 interface if available when encrypting.
+    - Test and validate the new path.
+
+2. Use OpenSSL AES-GCM in non-TLS mode, which means Go constructs the IV and OpenSSL honors it, but then we miss some required security checks that we would have to implement ourselves, namely:
+  - Enforce strictly monotonically increasing explicit nonces.
+  - Enforce explicit nonce values to be less than 2^64 - 1.
+  - Tets the new checks.
+
+#### Resolution
+
+We will implement option 2.
+
+Reasoning:
+- The additional security checks are easy to implement.
+- The changes are contained in `go-crypto-openssl`.
+- Option 1 would require non-trivial patching of the Go TLS stack, which we would need to keep up-to-date when `crypto/tls` changes.
+- Option 1 has higher chances to introduce a behavior chance or a security bug.
+
+Drawbacks:
+- OpenSSL might implement additional IV checks in future versions when running in TLS mode, and we will not benefit from them. We will have to keep an eye out for changes in this area.
+- We will implement security checks that go outside the ideal scope of `go-crypto-openssl`, which is just to act at as a thin layer between Go and OpenSSL APIs without real security knowledge.
+

--- a/docs/go-openssl-compat.md
+++ b/docs/go-openssl-compat.md
@@ -35,7 +35,7 @@ When AES-GCM is used to encrypt a TLS payload (aka TLS mode), FIPS 140-2 IG A.5 
 - Fixed 4 bytes field which identifies the encryption context and is reused in different Seal operations using the same key.
 - Explicit 8 bytes field which identifies the Seal operation within an encryption context. This field must not be reused in the same encryption context and should be set using a counter incremented in every Seal operation within an encryption context.
 
-The [FIPS 140-2 Implementation Guidance)(https://csrc.nist.gov/csrc/media/projects/cryptographic-module-validation-program/documents/fips140-2/fips1402ig.pdf) requires that the explicit IV counter does not exceed the 2^64-1 value.
+The [FIPS 140-2 Implementation Guidance](https://csrc.nist.gov/csrc/media/projects/cryptographic-module-validation-program/documents/fips140-2/fips1402ig.pdf) requires that the explicit IV counter does not exceed the 2^64-1 value.
 
 As it is implemented in BoringCrypto, the Go TLS stack is responsible for constructing a valid, unique Key/IV pair. This is passed to the `Seal` method (backed by BoringSSL or OpenSSL) with the expectation that the nonce (IV) is honored. 
 

--- a/docs/go-openssl-compat.md
+++ b/docs/go-openssl-compat.md
@@ -1,16 +1,14 @@
 # Compatibility of Go BoringCrypto and OpenSSL
 
-## Goal
-
-List implementation decisions taken to smooth out differences between Go BoringCrypto expectations and OpenSSL behavior.
+This document lists implementation decisions taken to smooth out differences between Go BoringCrypto expectations and OpenSSL behavior.
 
 ## Background
 
 Go BoringCrypto branch delegates core cryptographic algorithms to BoringSSL. Go does not support pluggable crypto backends, so in order to support BoringSSL, the BoringCrypto branch contains non-trivial modifications to several `crypto` packages. These modifications are not generic abstractions over crypto algorithms as they specifically target BoringSSL compatibility.
 
-The BoringSSL library was forked from OpenSSL 1.0.2 beta, a version that `go-crypto-openssl`supports and that already makes heavy use of the EVP interface. This fact facilitates the translation from BoringSSL to OpenSSL functions. Yet, Go BoringCrypto implements some algorithms using functions that are either deprecated in newer -but supported by us- OpenSSL versions or directly non-existing.
+The BoringSSL library was forked from OpenSSL 1.0.2 beta, a version that `go-crypto-openssl` supports and that already makes heavy use of the EVP interface. This fact facilitates the translation from BoringSSL to OpenSSL functions. Yet, Go BoringCrypto implements some algorithms using functions that are either deprecated or do not exist in the newer OpenSSL versions we support.
 
-In this situations were there is no direct mapping, we try to combine several OpenSSL functions so the security is not compromised, being the trade-off between speed and maintainability.
+In this situation where there is no direct mapping, we try to combine several OpenSSL functions so the security is not compromised, with a trade-off between speed and maintainability.
 
 ## Implementation decisions
 
@@ -31,25 +29,25 @@ Go abstracts this algorithm using the `Seal` method in the [cipher.AEAD](https:/
 
 `Seal(dst, nonce, plaintext, additionalData []byte) []byte`
 
-Where dst is just a backing memory buffer to reduce allocations and the returned byte slice is the ciphertext with the authentication tag appended.
+> `dst` is just a backing memory buffer to reduce allocations. The returned byte slice is `dst` with the ciphertext and the authentication tag appended.
 
 When AES-GCM is used to encrypt a TLS payload (aka TLS mode), FIPS 140-2 IG A.5 ["Key/IV Pair Uniqueness * Requirements from SP 800-38D"](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf), and the general security consensus, requires constructing the IV parameter deterministically by concatenating two fields:
 - Fixed 4 bytes field which identifies the encryption context and is reused in different Seal operations using the same key.
 - Explicit 8 bytes field which identifies the Seal operation within an encryption context. This field must not be reused in the same encryption context and should be set using a counter incremented in every Seal operation within an encryption context.
 
-As it is implemented in BoringCrypto, Go TLS stack is the one responsible of constructing a valid uniq Key/IV pair, which is passed the `Seal` method (backed by BoringSSL or OpenSSL) with the expectation that the nonce is honored. 
+As it is implemented in BoringCrypto, the Go TLS stack is responsible for constructing a valid, unique Key/IV pair. This is passed to the `Seal` method (backed by BoringSSL or OpenSSL) with the expectation that the nonce (IV) is honored. 
 
 #### BoringSSL
 
-BoringSSL implements the AES-GCM TLS encryption using the [EVP_AEAD_CTX_seal](https://man.openbsd.org/EVP_AEAD_CTX_seal.3) on-shot function, which have a one-to-one mapping with Go's `Seal` method and also enforces that the provided nonce matches the FIPS 140-2 IG A.5 requirements. So BoringSSL honors Go's IV and at the same time ensures it is secure.
+BoringSSL implements the AES-GCM TLS encryption using the [EVP_AEAD_CTX_seal](https://man.openbsd.org/EVP_AEAD_CTX_seal.3) one-shot function, which has a one-to-one mapping with Go's `Seal` method and also enforces that the provided nonce matches the FIPS 140-2 IG A.5 requirements. So, BoringSSL honors Go's IV and at the same time ensures it is secure.
 
 #### OpenSSL
 
-OpenSSL does not provide the `EVP_AEAD_CTX_seal` function, so AES-GCM should be implemented using several several EVP_ENCRYPT* functions, as described in [here](https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption). The problem with this recipe is that it does not enforce the additional TLS requirements, it just blindly uses whatever IV is passed.
+OpenSSL does not provide the `EVP_AEAD_CTX_seal` function, so AES-GCM should be implemented using several several `EVP_ENCRYPT*` functions, as described [here](https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption). The problem with this recipe is that it does not enforce the additional TLS requirements: it just blindly uses whatever IV is passed.
 
-This is because OpenSSL don't expect that recipe to be used for AES-GCM TLS encryption, but it provided instead a control parameter, EVP_CTRL_AEAD_TLS1_AAD, that when applied to an encryption context it makes it work in TLS-mode and completely change the encryption workflow (more details [here](https://beta.openssl.org/docs/manmaster/man3/EVP_CipherInit_ex.html#tlsivfixed-OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED-octet-string)).
+This is because OpenSSL doesn't expect that recipe to be used for AES-GCM TLS encryption. It provides instead a control parameter `EVP_CTRL_AEAD_TLS1_AAD` that when applied to an encryption context, makes it work in TLS-mode and completely changes the encryption workflow (more details [here](https://beta.openssl.org/docs/manmaster/man3/EVP_CipherInit_ex.html#tlsivfixed-OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED-octet-string)).
 
-The main difference is that the explicit IV field is no longer managed by the caller but by the OpenSSL encryption context, incrementing it on every Seal operation and applying some additional checks. This means that OpenSSL won't honor the IV constructed by Go, and therefore it will make Go send corrupted packaged to the wire.
+The main difference is that the explicit IV field is no longer managed by the caller but by the OpenSSL encryption context, incrementing it on every Seal operation and applying some additional checks. This means that OpenSSL won't honor the IV constructed by Go, and therefore it will make Go send corrupted packages to the wire.
 
 #### Assumptions
 
@@ -57,7 +55,7 @@ The main difference is that the explicit IV field is no longer managed by the ca
 
 #### Options
 
-1. Use OpenSSL AES-GCM in TLS mode, which means IV construction is secured inside OpenSSL context but Go expectations are not meet, therefore it requires the following changes to Go TLS stack:
+1. Use OpenSSL AES-GCM in TLS mode, which means IV construction is secured inside OpenSSL context but Go expectations are not met. Therefore, it requires the following changes to Go TLS stack:
   - In `go-crypto-openssl`, change `NewGCMTLS` to accept the 4 bytes fixed IV field.
   - In `crypto/tls`:
     - Define a new AEAD-like interface, i.e. `AEAD2`, whose `Seal` method does not accept an IV and returns a byte slice with iv+ciphertext+tag.
@@ -66,10 +64,10 @@ The main difference is that the explicit IV field is no longer managed by the ca
     - Use the AEAD2 interface if available when encrypting.
     - Test and validate the new path.
 
-2. Use OpenSSL AES-GCM in non-TLS mode, which means Go constructs the IV and OpenSSL honors it, but then we miss some required security checks that we would have to implement ourselves, namely:
+2. Use OpenSSL AES-GCM in non-TLS mode, which means Go constructs the IV and OpenSSL honors it, but we miss some required security checks. Therefore, we would have to implement them ourselves, namely:
   - Enforce strictly monotonically increasing explicit nonces.
   - Enforce explicit nonce values to be less than 2^64 - 1.
-  - Tets the new checks.
+  - Test the new checks.
 
 #### Resolution
 
@@ -83,5 +81,5 @@ Reasoning:
 
 Drawbacks:
 - OpenSSL might implement additional IV checks in future versions when running in TLS mode, and we will not benefit from them. We will have to keep an eye out for changes in this area.
-- We will implement security checks that go outside the ideal scope of `go-crypto-openssl`, which is just to act at as a thin layer between Go and OpenSSL APIs without real security knowledge.
+- Adding security checks goes outside the ideal scope of `go-crypto-openssl`, which is just to act at as a thin layer between Go and OpenSSL APIs without real security knowledge.
 

--- a/docs/go-openssl-compat.md
+++ b/docs/go-openssl-compat.md
@@ -1,12 +1,12 @@
-# Compatibility of Go BoringCrypto and OpenSSL
+# Compatibility of dev.boringcrypto and OpenSSL
 
-This document lists implementation decisions taken to smooth out differences between Go BoringCrypto expectations and OpenSSL behavior.
+This document lists implementation decisions taken to smooth out differences between dev.boringcrypto expectations and OpenSSL behavior.
 
 ## Background
 
-Go BoringCrypto branch delegates core cryptographic algorithms to BoringSSL. Go does not support pluggable crypto backends, so in order to support BoringSSL, the BoringCrypto branch contains non-trivial modifications to several `crypto` packages. These modifications are not generic abstractions over crypto algorithms as they specifically target BoringSSL compatibility.
+dev.boringcrypto branch delegates core cryptographic algorithms to BoringSSL. Go does not support pluggable crypto backends, so in order to support BoringSSL, the BoringCrypto branch contains non-trivial modifications to several `crypto` packages. These modifications are not generic abstractions over crypto algorithms as they specifically target BoringSSL compatibility.
 
-The BoringSSL library was forked from OpenSSL 1.0.2 beta, a version that `go-crypto-openssl` supports and that already makes heavy use of the EVP interface. This fact facilitates the translation from BoringSSL to OpenSSL functions. Yet, Go BoringCrypto implements some algorithms using functions that are either deprecated or do not exist in the newer OpenSSL versions we support.
+The BoringSSL library was forked from OpenSSL 1.0.2 beta, a version that `go-crypto-openssl` supports and that already makes heavy use of the EVP interface. This fact facilitates the translation from BoringSSL to OpenSSL functions. Yet, dev.boringcrypto implements some algorithms using functions that are either deprecated or do not exist in the newer OpenSSL versions we support.
 
 In this situation where there is no direct mapping, we try to combine several OpenSSL functions so the security is not compromised, with a trade-off between speed and maintainability.
 
@@ -35,6 +35,8 @@ When AES-GCM is used to encrypt a TLS payload (aka TLS mode), FIPS 140-2 IG A.5 
 - Fixed 4 bytes field which identifies the encryption context and is reused in different Seal operations using the same key.
 - Explicit 8 bytes field which identifies the Seal operation within an encryption context. This field must not be reused in the same encryption context and should be set using a counter incremented in every Seal operation within an encryption context.
 
+The [FIPS 140-2 Implementation Guidance)(https://csrc.nist.gov/csrc/media/projects/cryptographic-module-validation-program/documents/fips140-2/fips1402ig.pdf) requires that the explicit IV counter does not exceed the 2^64-1 value.
+
 As it is implemented in BoringCrypto, the Go TLS stack is responsible for constructing a valid, unique Key/IV pair. This is passed to the `Seal` method (backed by BoringSSL or OpenSSL) with the expectation that the nonce (IV) is honored. 
 
 #### BoringSSL
@@ -43,7 +45,7 @@ BoringSSL implements the AES-GCM TLS encryption using the [EVP_AEAD_CTX_seal](ht
 
 #### OpenSSL
 
-OpenSSL does not provide the `EVP_AEAD_CTX_seal` function, so AES-GCM should be implemented using several several `EVP_ENCRYPT*` functions, as described [here](https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption). The problem with this recipe is that it does not enforce the additional TLS requirements: it just blindly uses whatever IV is passed.
+OpenSSL does not provide the `EVP_AEAD_CTX_seal` function, so AES-GCM should be implemented using several `EVP_ENCRYPT*` functions, as described [here](https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption). The problem with this recipe is that it does not enforce the additional TLS requirements: it just blindly uses whatever IV is passed.
 
 This is because OpenSSL doesn't expect that recipe to be used for AES-GCM TLS encryption. It provides instead a control parameter `EVP_CTRL_AEAD_TLS1_AAD` that when applied to an encryption context, makes it work in TLS-mode and completely changes the encryption workflow (more details [here](https://beta.openssl.org/docs/manmaster/man3/EVP_CipherInit_ex.html#tlsivfixed-OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED-octet-string)).
 
@@ -56,18 +58,18 @@ The main difference is that the explicit IV field is no longer managed by the ca
 #### Options
 
 1. Use OpenSSL AES-GCM in TLS mode, which means IV construction is secured inside OpenSSL context but Go expectations are not met. Therefore, it requires the following changes to Go TLS stack:
-  - In `go-crypto-openssl`, change `NewGCMTLS` to accept the 4 bytes fixed IV field.
-  - In `crypto/tls`:
-    - Define a new AEAD-like interface, i.e. `AEAD2`, whose `Seal` method does not accept an IV and returns a byte slice with iv+ciphertext+tag.
-    - Construct the AES-GCM TLS cipher using the new method.
-    - Don't generate an IV when the cipher implements the AEAD2 interface.
-    - Use the AEAD2 interface if available when encrypting.
-    - Test and validate the new path.
+    - In `go-crypto-openssl`, change `NewGCMTLS` to accept the 4 bytes fixed IV field.
+    - In `crypto/tls`:
+        - Define a new AEAD-like interface, i.e. `AEAD2`, whose `Seal` method does not accept an IV and returns a byte slice with iv+ciphertext+tag.
+        - Construct the AES-GCM TLS cipher using the new method.
+        - Don't generate an IV when the cipher implements the AEAD2 interface.
+        - Use the AEAD2 interface if available when encrypting.
+        - Test and validate the new path.
 
 2. Use OpenSSL AES-GCM in non-TLS mode, which means Go constructs the IV and OpenSSL honors it, but we miss some required security checks. Therefore, we would have to implement them ourselves, namely:
-  - Enforce strictly monotonically increasing explicit nonces.
-  - Enforce explicit nonce values to be less than 2^64 - 1.
-  - Test the new checks.
+    - Enforce strictly monotonically increasing explicit nonces.
+    - Enforce explicit nonce values to be less than 2^64 - 1.
+    - Test the new checks.
 
 #### Resolution
 

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -361,7 +361,7 @@ func (g *aesGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 		// but OpenSSL does not perform this check, so it is implemented here.
 		const maxUint64 = 1<<64 - 1
 		counter := bigUint64(nonce[gcmTlsFixedNonceSize:])
-		if g.minNextNonce == maxUint64 {
+		if counter == maxUint64 {
 			panic("cipher: nonce counter must be less than 2^64 - 1")
 		}
 		if counter < g.minNextNonce {

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -368,7 +368,7 @@ func (g *aesGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 			panic("cipher: nonce counter must be strictly monotonically increasing")
 		}
 		defer func() {
-			g.minNextNonce++
+			g.minNextNonce = counter + 1
 		}()
 	}
 

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -498,6 +498,7 @@ func newCipherCtx(cipher C.GO_EVP_CIPHER_PTR, mode C.int, key, iv []byte) (C.GO_
 		return nil, fail("unable to create EVP cipher ctx")
 	}
 	if C.go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), mode) != 1 {
+		C.go_openssl_EVP_CIPHER_CTX_free(ctx)
 		return nil, fail("unable to initialize EVP cipher ctx")
 	}
 	return ctx, nil

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -460,7 +460,7 @@ func newCipherCtx(cipher C.GO_EVP_CIPHER_PTR, mode C.int, key, iv []byte) (C.GO_
 }
 
 func bigUint64(b []byte) uint64 {
-	_ = b[7]
+	_ = b[7] // bounds check hint to compiler; see go.dev/issue/14808
 	return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
 		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
 }

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -357,8 +357,8 @@ func (g *aesGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 			panic("cipher: incorrect additional data length given to GCM TLS")
 		}
 		// BoringCrypto enforces strictly monotonically increasing explicit nonces
-		// and to fail after 2^64 - 1 keys for as per FIPS 140-2 IG A.5,
-		// but OpenSSL does not perform this check.
+		// and to fail after 2^64 - 1 keys as per FIPS 140-2 IG A.5,
+		// but OpenSSL does not perform this check, so it is implemented here.
 		const maxUint64 = 1<<64 - 1
 		counter := bigUint64(nonce[gcmTlsFixedNonceSize:])
 		if g.minNextNonce == maxUint64 {

--- a/openssl/aes_test.go
+++ b/openssl/aes_test.go
@@ -74,6 +74,8 @@ func TestSealAndOpenTLS(t *testing.T) {
 	}
 	nonce := []byte{0x91, 0xc7, 0xa7, 0x54, 0, 0, 0, 0, 0, 0, 0, 0}
 	nonce1 := []byte{0x91, 0xc7, 0xa7, 0x54, 0, 0, 0, 0, 0, 0, 0, 1}
+	nonce9 := []byte{0x91, 0xc7, 0xa7, 0x54, 0, 0, 0, 0, 0, 0, 0, 9}
+	nonce10 := []byte{0x91, 0xc7, 0xa7, 0x54, 0, 0, 0, 0, 0, 0, 0, 10}
 	plainText := []byte{0x01, 0x02, 0x03}
 	additionalData := make([]byte, 13)
 	additionalData[11] = byte(len(plainText) >> 8)
@@ -83,6 +85,10 @@ func TestSealAndOpenTLS(t *testing.T) {
 		gcm.Seal(nil, nonce, plainText, additionalData)
 	})
 	sealed1 := gcm.Seal(nil, nonce1, plainText, additionalData)
+	gcm.Seal(nil, nonce10, plainText, additionalData)
+	assertPanic(t, func() {
+		gcm.Seal(nil, nonce9, plainText, additionalData)
+	})
 	if bytes.Equal(sealed, sealed1) {
 		t.Errorf("different nonces should produce different outputs\ngot: %#v\nexp: %#v", sealed, sealed1)
 	}

--- a/openssl/aes_test.go
+++ b/openssl/aes_test.go
@@ -391,10 +391,8 @@ func BenchmarkAESGCM_Seal(b *testing.B) {
 	aesgcm, _ := c.(extraModes).NewGCM(gcmStandardNonceSize, gcmTagSize)
 	var out []byte
 
-	ct := aesgcm.Seal(nil, nonce[:], buf[:], ad[:])
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		out, _ = aesgcm.Open(out[:0], nonce[:], ct, ad[:])
+		out = aesgcm.Seal(out[:0], nonce[:], buf, ad[:])
 	}
 }


### PR DESCRIPTION
This PR can be reviewed commit by commit.

There are two main changes:

- First commit: Long story short, it adds some security checks to AES-GCM Seal method when sealing a TLS payload. I've added a new document with the detailed description of why we weren't implementing those checks before and how we are implementing them now.
- Following commits: While investigating the missing checks issue I noticed that Go, OpenSSL and BoringSSL have highly optimized routines for AES-GCM, but we were just doing the bare minimum. Doing a quick web search one can find many reports, such as [this one](https://www.f5.com/labs/articles/threat-intelligence/the-2021-tls-telemetry-report), showing that AES-GCM accounts for almost 95% of all TLS 1.2 and 1.3 traffic. So it is a no-brainer to optimize it as much as reasonable.
This I what I did:
    - Reuse the same cipher context in all the Go `aesGCM` lifetime, which reduces cgo calls and helps reusing OpenSSL cipher context backing memory buffers.
    - Batch all Seal/Open cgo calls into one, which means going from 5 calls to 1.

And the results speak by themselves:

```txt
name           old time/op    new time/op     delta
AESGCM_Open-4    1.92µs ± 4%     0.40µs ± 7%   -78.92%  (p=0.000 n=10+10)
AESGCM_Seal-4    1.89µs ± 2%     0.41µs ± 4%   -78.49%  (p=0.000 n=9+10)

name           old speed      new speed       delta
AESGCM_Open-4  33.4MB/s ± 4%  158.4MB/s ± 6%  +374.66%  (p=0.000 n=10+10)
AESGCM_Seal-4  33.9MB/s ± 2%  157.7MB/s ± 4%  +365.16%  (p=0.000 n=9+10)

name           old B/op       new B/op        delta
AESGCM_Open-4     48.0B ± 0%       0.0B       -100.00%  (p=0.000 n=10+10)
AESGCM_Seal-4     48.0B ± 0%       0.0B       -100.00%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op   delta
AESGCM_Open-4      4.00 ± 0%       0.00       -100.00%  (p=0.000 n=10+10)
AESGCM_Seal-4      4.00 ± 0%       0.00       -100.00%  (p=0.000 n=10+10)
```
