### PR TITLE
checkheader: check constant values

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,4 @@ ARG VARIANT=1.17-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get remove -y libssl-dev
+    && apt-get install -y build-essential

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The `libcrypto` shared library file name varies among different platforms, so a 
 
 This algorithm can be overridden by setting the environment variable `GO_OPENSSL_VERSION_OVERRIDE` to the desired version string. For example, `GO_OPENSSL_VERSION_OVERRIDE="1.1.1k-fips"` makes the runtime look for the shared library `libcrypto.so.1.1.1k-fips` before running the checks for well-known versions.
 
+### Building without OpenSSL headers
+
+The `openssl` package does not use any symbol from the OpenSSL headers. There is no need that have them installed to build an application which imports this library.
+
+Microsoft CI verifies that all the functions and constants defined in our headers match the ones in the OpenSSL headers for every supported OpenSSL version.
+
 ### Portable OpenSSL
 
 The OpenSSL bindings are implemented in such a way that the OpenSSL version used when building a program does not have to match with the OpenSSL version used when running it.

--- a/cmd/checkheader/go.mod
+++ b/cmd/checkheader/go.mod
@@ -1,3 +1,0 @@
-module github.com/microsoft/go-crypto-openssl/cmd/checkheader
-
-go 1.16

--- a/cmd/checkheader/main.go
+++ b/cmd/checkheader/main.go
@@ -20,6 +20,8 @@ import (
 // - Blank lines are discarded.
 // - Comments are discarded unless they contain a C directive, i.e #include, #if or #endif.
 // - Typedefs following this pattern "typedef void* GO_%name%_PTR" are translated into "#define %name% GO_%name%_PTR".
+// - Enums are validated against their definition in the OpenSSL headers. Example:
+//   "enum { GO_EVP_CTRL_GCM_SET_TAG = 0x11 }" => "_Static_assert(EVP_CTRL_GCM_SET_TAG == 0x11);"
 // - Function macros are validated against their definition in the OpenSSL headers. Example:
 //   "DEFINEFUNC(int, RAND_bytes, (unsigned char *a0, int a1), (a0, a1))" => "int(*__check_0)(unsigned char *, int) = RAND_bytes;"
 // - Function macros can be excluded when checking old OpenSSL versions by prepending '/*check:from=%version%*/', %version% being a version string such as '1.1.1' or '3.0.0'.
@@ -112,7 +114,7 @@ func generate(header string) (string, error) {
 				enum = false
 				continue
 			}
-			checkEnum(&b, l)
+			tryConvertEnum(&b, l)
 			continue
 		}
 		if strings.HasPrefix(l, "enum {") {
@@ -145,7 +147,7 @@ func tryConvertDirective(w io.Writer, l string) bool {
 
 // tryConvertTypedef converts a typedef contained in the line l
 // into a #define pointing to the corresponding OpenSSL type.
-// Only void* typedefs starting with GO are converted.
+// Only void* typedefs starting with GO_ are converted.
 // If l does not contain a typedef it does nothing and returns false.
 func tryConvertTypedef(w io.Writer, l string) bool {
 	if !strings.HasPrefix(l, "typedef void* GO_") {
@@ -164,7 +166,11 @@ func tryConvertTypedef(w io.Writer, l string) bool {
 	return true
 }
 
-func checkEnum(w io.Writer, l string) {
+// tryConvertEnum adds a static check which verifies that
+// the enum contained in the line l
+// matches the corresponding OpenSSL value.
+// Only enum names starting with GO_ are converted.
+func tryConvertEnum(w io.Writer, l string) {
 	if !strings.HasPrefix(l, "GO_") {
 		return
 	}
@@ -172,7 +178,7 @@ func checkEnum(w io.Writer, l string) {
 		l = l[:len(l)-1]
 	}
 	split := strings.SplitN(l, " = ", 2)
-	name := split[0][3:]
+	name := split[0][len("GO_"):]
 	fmt.Fprintf(w, "#ifdef %s\n", name)
 	fmt.Fprintf(w, "_Static_assert(%s == %s, \"%s\");\n", name, split[1], name)
 	fmt.Fprintln(w, "#endif")

--- a/cmd/checkheader/main.go
+++ b/cmd/checkheader/main.go
@@ -110,11 +110,11 @@ func generate(header string) (string, error) {
 	for sc.Scan() {
 		l := strings.TrimSpace(sc.Text())
 		if enum {
-			if strings.HasPrefix(l, "}") {
+			if !strings.HasPrefix(l, "}") {
+				tryConvertEnum(&b, l)
+			} else {
 				enum = false
-				continue
 			}
-			tryConvertEnum(&b, l)
 			continue
 		}
 		if strings.HasPrefix(l, "enum {") {
@@ -178,6 +178,10 @@ func tryConvertEnum(w io.Writer, l string) {
 		l = l[:len(l)-1]
 	}
 	split := strings.SplitN(l, " = ", 2)
+	if len(split) < 2 {
+		log.Printf("unexpected enum definition in function line: %s\n", l)
+		return
+	}
 	name := split[0][len("GO_"):]
 	fmt.Fprintf(w, "#ifdef %s\n", name)
 	fmt.Fprintf(w, "_Static_assert(%s == %s, \"%s\");\n", name, split[1], name)

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -375,7 +375,7 @@ func (g *aesGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	}
 	encLen += encFinalLen
 
-	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(&out[encLen])) != 1 {
+	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(&out[encLen])) != 1 {
 		panic(fail("EVP_CIPHER_CTX_seal"))
 	}
 	encLen += 16
@@ -435,7 +435,7 @@ func (g *aesGCM) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, er
 	}
 
 	// Set expected tag value. Works in OpenSSL 1.0.1d and later.
-	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(&tag[0])) != 1 {
+	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(&tag[0])) != 1 {
 		return clearAndFail(errOpen)
 	}
 

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -54,13 +54,13 @@ var errUnsupportedCurve = errors.New("openssl: unsupported elliptic curve")
 func curveNID(curve string) (C.int, error) {
 	switch curve {
 	case "P-224":
-		return C.NID_secp224r1, nil
+		return C.GO_NID_secp224r1, nil
 	case "P-256":
-		return C.NID_X9_62_prime256v1, nil
+		return C.GO_NID_X9_62_prime256v1, nil
 	case "P-384":
-		return C.NID_secp384r1, nil
+		return C.GO_NID_secp384r1, nil
 	case "P-521":
-		return C.NID_secp521r1, nil
+		return C.GO_NID_secp521r1, nil
 	}
 	return 0, errUnknownCurve
 }
@@ -84,8 +84,8 @@ func newECKey(curve string, X, Y, D *big.Int) (pkey C.GO_EVP_PKEY_PTR, err error
 	if nid, err = curveNID(curve); err != nil {
 		return nil, err
 	}
-	var bx, by *C.BIGNUM
-	var key *C.EC_KEY
+	var bx, by C.GO_BIGNUM_PTR
+	var key C.GO_EC_KEY_PTR
 	defer func() {
 		if bx != nil {
 			C.go_openssl_BN_free(bx)
@@ -129,7 +129,7 @@ func newECKey(curve string, X, Y, D *big.Int) (pkey C.GO_EVP_PKEY_PTR, err error
 	if pkey = C.go_openssl_EVP_PKEY_new(); pkey == nil {
 		return nil, newOpenSSLError("EVP_PKEY_new failed")
 	}
-	if C.go_openssl_EVP_PKEY_assign(pkey, C.EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
 		return nil, newOpenSSLError("EVP_PKEY_assign failed")
 	}
 	return pkey, nil
@@ -181,7 +181,7 @@ func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
 }
 
 func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
-	pkey, err := generateEVPPKey(C.EVP_PKEY_EC, 0, curve)
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -7,33 +7,10 @@
 
 #include "openssl_funcs.h"
 
-#include <openssl/ossl_typ.h>
-#include <openssl/opensslv.h>
-#include <openssl/crypto.h>
-#include <openssl/err.h>
-#include <openssl/rand.h>
-#include <openssl/obj_mac.h>
-#include <openssl/sha.h>
-#include <openssl/evp.h>
-#include <openssl/md5.h>
-#include <openssl/hmac.h>
-#include <openssl/aes.h>
-#include <openssl/bn.h>
-#include <openssl/ec.h>
-#include <openssl/ecdsa.h>
-#include <openssl/rsa.h>
-
 int go_openssl_version_major(void* handle);
 int go_openssl_version_minor(void* handle);
 int go_openssl_thread_setup(void);
 void go_openssl_load_functions(void* handle, int major, int minor);
-
-#define GO_OPENSSL_INIT_LOAD_CRYPTO_STRINGS 0x00000002L
-#define GO_OPENSSL_INIT_ADD_ALL_CIPHERS 0x00000004L
-#define GO_OPENSSL_INIT_ADD_ALL_DIGESTS 0x00000008L
-#define GO_OPENSSL_INIT_LOAD_CONFIG 0x00000040L
-#define GO_AES_ENCRYPT 1
-#define GO_AES_DECRYPT 0
 
 // Define pointers to all the used OpenSSL functions.
 // Calling C function pointers from Go is currently not supported.

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -36,7 +36,7 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		// HMAC_Init will try and reuse the key from the ctx. This is
 		// not the bahavior previously implemented, so as a workaround
 		// we pass an "empty" key.
-		hkey = make([]byte, C.EVP_MAX_MD_SIZE)
+		hkey = make([]byte, C.GO_EVP_MAX_MD_SIZE)
 	}
 	hmac := &opensslHMAC{
 		md:        md,

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -242,7 +242,7 @@ type fail string
 
 func (e fail) Error() string { return "openssl: " + string(e) + " failed" }
 
-func bigToBN(x *big.Int) *C.BIGNUM {
+func bigToBN(x *big.Int) C.GO_BIGNUM_PTR {
 	if x == nil {
 		return nil
 	}
@@ -250,7 +250,7 @@ func bigToBN(x *big.Int) *C.BIGNUM {
 	return C.go_openssl_BN_bin2bn(base(raw), C.int(len(raw)), nil)
 }
 
-func bnToBig(bn *C.BIGNUM) *big.Int {
+func bnToBig(bn C.GO_BIGNUM_PTR) *big.Int {
 	if bn == nil {
 		return nil
 	}

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -12,6 +12,56 @@
 #include <stdlib.h> // size_t
 #include <stdint.h> // uint64_t
 
+// #include "openssl/crypto.h"
+enum {
+    GO_OPENSSL_INIT_LOAD_CRYPTO_STRINGS = 0x00000002L,
+    GO_OPENSSL_INIT_ADD_ALL_CIPHERS = 0x00000004L,
+    GO_OPENSSL_INIT_ADD_ALL_DIGESTS = 0x00000008L,
+    GO_OPENSSL_INIT_LOAD_CONFIG = 0x00000040L
+};
+
+// #include "openssl/aes.h"
+enum {
+    GO_AES_ENCRYPT = 1,
+    GO_AES_DECRYPT = 0
+};
+
+// #include "openssl/evp.h"
+enum {
+    GO_EVP_CTRL_GCM_GET_TAG = 0x10,
+    GO_EVP_CTRL_GCM_SET_TAG = 0x11,
+    GO_EVP_PKEY_CTRL_MD = 1,
+    GO_EVP_PKEY_RSA = 6,
+    GO_EVP_PKEY_EC = 408,
+    GO_EVP_MAX_MD_SIZE = 64
+};
+
+// #include "openssl/ec.h"
+enum {
+    GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001
+};
+
+// #include "openssl/obj_mac.h"
+enum {
+    GO_NID_X9_62_prime256v1 = 415,
+    GO_NID_secp224r1 = 713,
+    GO_NID_secp384r1 = 715,
+    GO_NID_secp521r1 = 716
+};
+
+// #include "openssl/rsa.h"
+enum {
+    GO_RSA_PKCS1_PADDING = 1,
+    GO_RSA_NO_PADDING = 3,
+    GO_RSA_PKCS1_OAEP_PADDING = 4,
+    GO_RSA_PKCS1_PSS_PADDING = 6,
+    GO_EVP_PKEY_CTRL_RSA_PADDING = 0x1001,
+    GO_EVP_PKEY_CTRL_RSA_PSS_SALTLEN = 0x1002,
+    GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS = 0x1003,
+    GO_EVP_PKEY_CTRL_RSA_OAEP_MD = 0x1009,
+    GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A
+};
+
 typedef void* GO_EVP_CIPHER_PTR;
 typedef void* GO_EVP_CIPHER_CTX_PTR;
 typedef void* GO_EVP_PKEY_PTR;
@@ -22,6 +72,13 @@ typedef void* GO_HMAC_CTX_PTR;
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 typedef void* GO_OSSL_LIB_CTX_PTR;
 typedef void* GO_OSSL_PROVIDER_PTR;
+typedef void* GO_ENGINE_PTR;
+typedef void* GO_BIGNUM_PTR;
+typedef void* GO_BN_CTX_PTR;
+typedef void* GO_EC_KEY_PTR;
+typedef void* GO_EC_POINT_PTR;
+typedef void* GO_EC_GROUP_PTR;
+typedef void* GO_RSA_PTR;
 
 // List of all functions from the libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -87,7 +144,7 @@ DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (GO_OSSL_LIB_CTX_PTR
 DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, const char *propq), (libctx, propq)) \
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
-DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, ENGINE *impl), (ctx, type, impl)) \
+DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
@@ -106,7 +163,7 @@ DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_size, EVP_MD_size, (const GO_EVP_MD_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_cleanup, (GO_HMAC_CTX_PTR arg0), (arg0)) \
-DEFINEFUNC(int, HMAC_Init_ex, (GO_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const GO_EVP_MD_PTR arg3, ENGINE *arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(int, HMAC_Init_ex, (GO_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const GO_EVP_MD_PTR arg3, GO_ENGINE_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
 DEFINEFUNC(int, HMAC_Update, (GO_HMAC_CTX_PTR arg0, const unsigned char *arg1, size_t arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX_PTR arg0, unsigned char *arg1, unsigned int *arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC(int, HMAC_CTX_copy, (GO_HMAC_CTX_PTR dest, GO_HMAC_CTX_PTR src), (dest, src)) \
@@ -115,34 +172,34 @@ DEFINEFUNC_1_1(GO_HMAC_CTX_PTR, HMAC_CTX_new, (void), ()) \
 DEFINEFUNC_1_1(int, HMAC_CTX_reset, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EVP_CIPHER_CTX_PTR, EVP_CIPHER_CTX_new, (void), ()) \
 DEFINEFUNC(int, EVP_CIPHER_CTX_set_padding, (GO_EVP_CIPHER_CTX_PTR x, int padding), (x, padding)) \
-DEFINEFUNC(int, EVP_CipherInit_ex, (GO_EVP_CIPHER_CTX_PTR ctx, const GO_EVP_CIPHER_PTR type, ENGINE *impl, const unsigned char *key, const unsigned char *iv, int enc), (ctx, type, impl, key, iv, enc)) \
+DEFINEFUNC(int, EVP_CipherInit_ex, (GO_EVP_CIPHER_CTX_PTR ctx, const GO_EVP_CIPHER_PTR type, GO_ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc), (ctx, type, impl, key, iv, enc)) \
 DEFINEFUNC(int, EVP_CipherUpdate, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl), (ctx, out, outl, in, inl)) \
-DEFINEFUNC(BIGNUM *, BN_new, (void), ()) \
-DEFINEFUNC(void, BN_free, (BIGNUM * arg0), (arg0)) \
-DEFINEFUNC(void, BN_clear_free, (BIGNUM * arg0), (arg0)) \
-DEFINEFUNC(int, BN_num_bits, (const BIGNUM *arg0), (arg0)) \
-DEFINEFUNC(BIGNUM *, BN_bin2bn, (const unsigned char *arg0, int arg1, BIGNUM *arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC(int, BN_bn2bin, (const BIGNUM *arg0, unsigned char *arg1), (arg0, arg1)) \
-DEFINEFUNC(void, EC_GROUP_free, (EC_GROUP * arg0), (arg0)) \
-DEFINEFUNC(EC_POINT *, EC_POINT_new, (const EC_GROUP *arg0), (arg0)) \
-DEFINEFUNC(void, EC_POINT_free, (EC_POINT * arg0), (arg0)) \
-DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const EC_GROUP *arg0, const EC_POINT *arg1, BIGNUM *arg2, BIGNUM *arg3, BN_CTX *arg4), (arg0, arg1, arg2, arg3, arg4)) \
-DEFINEFUNC(EC_KEY *, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
-DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (EC_KEY *key, BIGNUM *x, BIGNUM *y), (key, x, y)) \
-DEFINEFUNC(void, EC_KEY_free, (EC_KEY * arg0), (arg0)) \
-DEFINEFUNC(const EC_GROUP *, EC_KEY_get0_group, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(int, EC_KEY_set_private_key, (EC_KEY * arg0, const BIGNUM *arg1), (arg0, arg1)) \
-DEFINEFUNC(const BIGNUM *, EC_KEY_get0_private_key, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(const EC_POINT *, EC_KEY_get0_public_key, (const EC_KEY *arg0), (arg0)) \
-DEFINEFUNC(RSA *, RSA_new, (void), ()) \
-DEFINEFUNC(void, RSA_free, (RSA * arg0), (arg0)) \
-DEFINEFUNC_1_1(int, RSA_set0_factors, (RSA * rsa, BIGNUM *p, BIGNUM *q), (rsa, p, q)) \
-DEFINEFUNC_1_1(int, RSA_set0_crt_params, (RSA * rsa, BIGNUM *dmp1, BIGNUM *dmp2, BIGNUM *iqmp), (rsa, dmp1, dmp2, iqmp)) \
-DEFINEFUNC_1_1(void, RSA_get0_crt_params, (const RSA *r, const BIGNUM **dmp1, const BIGNUM **dmq1, const BIGNUM **iqmp), (r, dmp1, dmq1, iqmp)) \
-DEFINEFUNC_1_1(int, RSA_set0_key, (RSA * r, BIGNUM *n, BIGNUM *e, BIGNUM *d), (r, n, e, d)) \
-DEFINEFUNC_1_1(void, RSA_get0_factors, (const RSA *rsa, const BIGNUM **p, const BIGNUM **q), (rsa, p, q)) \
-DEFINEFUNC_1_1(void, RSA_get0_key, (const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d), (rsa, n, e, d)) \
-DEFINEFUNC(int, EVP_EncryptInit_ex, (GO_EVP_CIPHER_CTX_PTR ctx, const GO_EVP_CIPHER_PTR type, ENGINE *impl, const unsigned char *key, const unsigned char *iv), (ctx, type, impl, key, iv)) \
+DEFINEFUNC(GO_BIGNUM_PTR, BN_new, (void), ()) \
+DEFINEFUNC(void, BN_free, (GO_BIGNUM_PTR arg0), (arg0)) \
+DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
+DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BIGNUM_PTR arg2), (arg0, arg1, arg2)) \
+DEFINEFUNC(int, BN_bn2bin, (const GO_BIGNUM_PTR arg0, unsigned char *arg1), (arg0, arg1)) \
+DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
+DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
+DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
+DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
+DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
+DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \
+DEFINEFUNC_1_1(int, RSA_set0_factors, (GO_RSA_PTR rsa, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q), (rsa, p, q)) \
+DEFINEFUNC_1_1(int, RSA_set0_crt_params, (GO_RSA_PTR rsa, GO_BIGNUM_PTR dmp1, GO_BIGNUM_PTR dmp2,GO_BIGNUM_PTR iqmp), (rsa, dmp1, dmp2, iqmp)) \
+DEFINEFUNC_1_1(void, RSA_get0_crt_params, (const GO_RSA_PTR r, const GO_BIGNUM_PTR *dmp1, const GO_BIGNUM_PTR *dmq1, const GO_BIGNUM_PTR *iqmp), (r, dmp1, dmq1, iqmp)) \
+DEFINEFUNC_1_1(int, RSA_set0_key, (GO_RSA_PTR r, GO_BIGNUM_PTR n, GO_BIGNUM_PTR e, GO_BIGNUM_PTR d), (r, n, e, d)) \
+DEFINEFUNC_1_1(void, RSA_get0_factors, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *p, const GO_BIGNUM_PTR *q), (rsa, p, q)) \
+DEFINEFUNC_1_1(void, RSA_get0_key, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *n, const GO_BIGNUM_PTR *e, const GO_BIGNUM_PTR *d), (rsa, n, e, d)) \
+DEFINEFUNC(int, EVP_EncryptInit_ex, (GO_EVP_CIPHER_CTX_PTR ctx, const GO_EVP_CIPHER_PTR type, GO_ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv), (ctx, type, impl, key, iv)) \
 DEFINEFUNC(int, EVP_EncryptUpdate, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl), (ctx, out, outl, in, inl)) \
 DEFINEFUNC(int, EVP_EncryptFinal_ex, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl), (ctx, out, outl)) \
 DEFINEFUNC(int, EVP_DecryptUpdate, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl),	(ctx, out, outl, in, inl)) \
@@ -166,12 +223,12 @@ DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
 /* Exclude it from headercheck tool when using previous OpenSSL versions. */ \
 /*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_size, EVP_PKEY_size, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(void, EVP_PKEY_free, (GO_EVP_PKEY_PTR arg0), (arg0)) \
-DEFINEFUNC(EC_KEY *, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
-DEFINEFUNC(RSA *, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC(GO_RSA_PTR, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(int, EVP_PKEY_assign, (GO_EVP_PKEY_PTR pkey, int type, void *key), (pkey, type, key)) \
 DEFINEFUNC(int, EVP_PKEY_verify, (GO_EVP_PKEY_CTX_PTR ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen), (ctx, sig, siglen, tbs, tbslen)) \
-DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new, (GO_EVP_PKEY_PTR arg0, ENGINE *arg1), (arg0, arg1)) \
-DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_id, (int id, ENGINE *e), (id, e)) \
+DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new, (GO_EVP_PKEY_PTR arg0, GO_ENGINE_PTR arg1), (arg0, arg1)) \
+DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_id, (int id, GO_ENGINE_PTR e), (id, e)) \
 DEFINEFUNC(int, EVP_PKEY_keygen_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_PKEY_keygen, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *ppkey), (ctx, ppkey)) \
 DEFINEFUNC(void, EVP_PKEY_CTX_free, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -12,7 +12,7 @@
 #include <stdlib.h> // size_t
 #include <stdint.h> // uint64_t
 
-// #include "openssl/crypto.h"
+// #include <openssl/crypto.h>
 enum {
     GO_OPENSSL_INIT_LOAD_CRYPTO_STRINGS = 0x00000002L,
     GO_OPENSSL_INIT_ADD_ALL_CIPHERS = 0x00000004L,
@@ -20,13 +20,13 @@ enum {
     GO_OPENSSL_INIT_LOAD_CONFIG = 0x00000040L
 };
 
-// #include "openssl/aes.h"
+// #include <openssl/aes.h>
 enum {
     GO_AES_ENCRYPT = 1,
     GO_AES_DECRYPT = 0
 };
 
-// #include "openssl/evp.h"
+// #include <openssl/evp.h>
 enum {
     GO_EVP_CTRL_GCM_GET_TAG = 0x10,
     GO_EVP_CTRL_GCM_SET_TAG = 0x11,
@@ -36,12 +36,12 @@ enum {
     GO_EVP_MAX_MD_SIZE = 64
 };
 
-// #include "openssl/ec.h"
+// #include <openssl/ec.h>
 enum {
     GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001
 };
 
-// #include "openssl/obj_mac.h"
+// #include <openssl/obj_mac.h>
 enum {
     GO_NID_X9_62_prime256v1 = 415,
     GO_NID_secp224r1 = 713,
@@ -49,7 +49,7 @@ enum {
     GO_NID_secp521r1 = 716
 };
 
-// #include "openssl/rsa.h"
+// #include <openssl/rsa.h>
 enum {
     GO_RSA_PKCS1_PADDING = 1,
     GO_RSA_NO_PADDING = 3,

--- a/openssl/openssl_lock_setup.c
+++ b/openssl/openssl_lock_setup.c
@@ -8,7 +8,6 @@
 
 #include <stdio.h>
 #include <pthread.h>
-#include <openssl/err.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
 
@@ -27,7 +26,7 @@ static MUTEX_TYPE *mutex_buf = NULL;
  
 static void locking_function(int mode, int n, const char *file, int line)
 {
-  if(mode & CRYPTO_LOCK)
+  if(mode & 1)
     MUTEX_LOCK(mutex_buf[n]);
   else
     MUTEX_UNLOCK(mutex_buf[n]);

--- a/openssl/openssl_lock_setup.c
+++ b/openssl/openssl_lock_setup.c
@@ -20,13 +20,14 @@
 #define MUTEX_LOCK(x)    pthread_mutex_lock(&(x))
 #define MUTEX_UNLOCK(x)  pthread_mutex_unlock(&(x))
 #define THREAD_ID        pthread_self()
- 
+#define CRYPTO_LOCK      0x01
+
 /* This array will store all of the mutexes available to OpenSSL. */ 
 static MUTEX_TYPE *mutex_buf = NULL;
  
 static void locking_function(int mode, int n, const char *file, int line)
 {
-  if(mode & 1)
+  if(mode & CRYPTO_LOCK)
     MUTEX_LOCK(mutex_buf[n]);
   else
     MUTEX_UNLOCK(mutex_buf[n]);

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -22,7 +22,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) 
 	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
 		return nil, nil, nil, nil, nil, nil, nil, nil, e
 	}
-	pkey, err := generateEVPPKey(C.EVP_PKEY_RSA, bits, "")
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_RSA, bits, "")
 	if err != nil {
 		return bad(err)
 	}
@@ -55,7 +55,7 @@ func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
 		C.go_openssl_RSA_free(key)
 		return nil, newOpenSSLError("EVP_PKEY_new failed")
 	}
-	if C.go_openssl_EVP_PKEY_assign(pkey, C.EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
 		C.go_openssl_RSA_free(key)
 		C.go_openssl_EVP_PKEY_free(pkey)
 		return nil, newOpenSSLError("EVP_PKEY_assign failed")
@@ -105,7 +105,7 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, err
 		C.go_openssl_RSA_free(key)
 		return nil, newOpenSSLError("EVP_PKEY_new failed")
 	}
-	if C.go_openssl_EVP_PKEY_assign(pkey, C.EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
 		C.go_openssl_RSA_free(key)
 		C.go_openssl_EVP_PKEY_free(pkey)
 		return nil, newOpenSSLError("EVP_PKEY_assign failed")
@@ -128,23 +128,23 @@ func (k *PrivateKeyRSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
 }
 
 func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-	return evpDecrypt(priv.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, ciphertext)
+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, ciphertext)
 }
 
 func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
-	return evpEncrypt(pub.withKey, C.RSA_PKCS1_OAEP_PADDING, h, label, msg)
+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, msg)
 }
 
 func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-	return evpDecrypt(priv.withKey, C.RSA_PKCS1_PADDING, nil, nil, ciphertext)
+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, ciphertext)
 }
 
 func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-	return evpEncrypt(pub.withKey, C.RSA_PKCS1_PADDING, nil, nil, msg)
+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, msg)
 }
 
 func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-	ret, err := evpDecrypt(priv.withKey, C.RSA_NO_PADDING, nil, nil, ciphertext)
+	ret, err := evpDecrypt(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, ciphertext)
 	if err != nil {
 		return nil, err
 	}
@@ -168,25 +168,25 @@ func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error)
 }
 
 func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-	return evpEncrypt(pub.withKey, C.RSA_NO_PADDING, nil, nil, msg)
+	return evpEncrypt(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, msg)
 }
 
 func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
 	if saltLen == 0 {
 		saltLen = -1 // RSA_PSS_SALTLEN_DIGEST
 	}
-	return evpSign(priv.withKey, C.RSA_PKCS1_PSS_PADDING, saltLen, h, hashed)
+	return evpSign(priv.withKey, C.GO_RSA_PKCS1_PSS_PADDING, saltLen, h, hashed)
 }
 
 func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 	if saltLen == 0 {
 		saltLen = -2 // RSA_PSS_SALTLEN_AUTO
 	}
-	return evpVerify(pub.withKey, C.RSA_PKCS1_PSS_PADDING, saltLen, h, sig, hashed)
+	return evpVerify(pub.withKey, C.GO_RSA_PKCS1_PSS_PADDING, saltLen, h, sig, hashed)
 }
 
 func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
-	return evpSign(priv.withKey, C.RSA_PKCS1_PADDING, 0, h, hashed)
+	return evpSign(priv.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, hashed)
 }
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
@@ -199,7 +199,7 @@ func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) err
 	}) == 0 {
 		return errors.New("crypto/rsa: verification error")
 	}
-	return evpVerify(pub.withKey, C.RSA_PKCS1_PADDING, 0, h, sig, hashed)
+	return evpVerify(pub.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, sig, hashed)
 }
 
 // rsa_st_1_0_2 is rsa_st memory layout in OpenSSL 1.0.2.
@@ -207,13 +207,13 @@ type rsa_st_1_0_2 struct {
 	_                C.int
 	_                C.long
 	_                [2]unsafe.Pointer
-	n, e, d          *C.BIGNUM
-	p, q             *C.BIGNUM
-	dmp1, dmq1, iqmp *C.BIGNUM
+	n, e, d          C.GO_BIGNUM_PTR
+	p, q             C.GO_BIGNUM_PTR
+	dmp1, dmq1, iqmp C.GO_BIGNUM_PTR
 	// It contains more fields, but we are not interesed on them.
 }
 
-func bnSet(b1 **C.BIGNUM, b2 *big.Int) {
+func bnSet(b1 *C.GO_BIGNUM_PTR, b2 *big.Int) {
 	if b2 == nil {
 		return
 	}
@@ -223,7 +223,7 @@ func bnSet(b1 **C.BIGNUM, b2 *big.Int) {
 	*b1 = bigToBN(b2)
 }
 
-func rsaSetKey(key *C.RSA, n, e, d *big.Int) bool {
+func rsaSetKey(key C.GO_RSA_PTR, n, e, d *big.Int) bool {
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		//r.d and d will be nil for public keys.
@@ -239,7 +239,7 @@ func rsaSetKey(key *C.RSA, n, e, d *big.Int) bool {
 	return C.go_openssl_RSA_set0_key(key, bigToBN(n), bigToBN(e), bigToBN(d)) == 1
 }
 
-func rsaSetFactors(key *C.RSA, p, q *big.Int) bool {
+func rsaSetFactors(key C.GO_RSA_PTR, p, q *big.Int) bool {
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		if (r.p == nil && p == nil) ||
@@ -253,7 +253,7 @@ func rsaSetFactors(key *C.RSA, p, q *big.Int) bool {
 	return C.go_openssl_RSA_set0_factors(key, bigToBN(p), bigToBN(q)) == 1
 }
 
-func rsaSetCRTParams(key *C.RSA, dmp1, dmq1, iqmp *big.Int) bool {
+func rsaSetCRTParams(key C.GO_RSA_PTR, dmp1, dmq1, iqmp *big.Int) bool {
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		if (r.dmp1 == nil && dmp1 == nil) ||
@@ -269,8 +269,8 @@ func rsaSetCRTParams(key *C.RSA, dmp1, dmq1, iqmp *big.Int) bool {
 	return C.go_openssl_RSA_set0_crt_params(key, bigToBN(dmp1), bigToBN(dmq1), bigToBN(iqmp)) == 1
 }
 
-func rsaGetKey(key *C.RSA) (*big.Int, *big.Int, *big.Int) {
-	var n, e, d *C.BIGNUM
+func rsaGetKey(key C.GO_RSA_PTR) (*big.Int, *big.Int, *big.Int) {
+	var n, e, d C.GO_BIGNUM_PTR
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		n, e, d = r.n, r.e, r.d
@@ -280,8 +280,8 @@ func rsaGetKey(key *C.RSA) (*big.Int, *big.Int, *big.Int) {
 	return bnToBig(n), bnToBig(e), bnToBig(d)
 }
 
-func rsaGetFactors(key *C.RSA) (*big.Int, *big.Int) {
-	var p, q *C.BIGNUM
+func rsaGetFactors(key C.GO_RSA_PTR) (*big.Int, *big.Int) {
+	var p, q C.GO_BIGNUM_PTR
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		p, q = r.p, r.q
@@ -291,8 +291,8 @@ func rsaGetFactors(key *C.RSA) (*big.Int, *big.Int) {
 	return bnToBig(p), bnToBig(q)
 }
 
-func rsaGetCRTParams(key *C.RSA) (*big.Int, *big.Int, *big.Int) {
-	var dmp1, dmq1, iqmp *C.BIGNUM
+func rsaGetCRTParams(key C.GO_RSA_PTR) (*big.Int, *big.Int, *big.Int) {
+	var dmp1, dmq1, iqmp C.GO_BIGNUM_PTR
 	if vMajor == 1 && vMinor == 0 {
 		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
 		dmp1, dmq1, iqmp = r.dmp1, r.dmq1, r.iqmp

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -42,10 +42,4 @@ cd "openssl-$version"
 ./config shared
 make -j$(nproc) build_libs
 
-rm -rf /usr/include/openssl
-rm -rf /usr/include/crypto
-
-cp -r -L ./include/openssl /usr/include
-# include/crypto only exists in some OpenSSL versions
-test -e ./include/crypto && cp -r -L ./include/crypto /usr/include
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"


### PR DESCRIPTION
The checkheader tool currently only checks for mismatching function definitions between our headers and OpenSSL development headers.

There is one remaining weak spot in our setup: we are using many constants defined in OpenSSL headers, i.e. `EVP_CTRL_GCM_SET_TAG`, and any of this constants value could be modified from one OpenSSL version to another. If the build-time and run-time OpenSSL versions do not agree on a particular constant value, then we would be using the build-time value in the runtime-environment, as constant values are burned into the binary when compiling.

Luckily this does not happen today, but I've already seen several constants (which we don't use) changing from OpenSSL 1 to OpenSSL 3, so better don't play with fire and teach checkheader to verify all constant values.

In order to do so, this PR removes all constants coming from OpenSSL headers and change them for enums defined in our headers. The checkheader tool will translate all enums whose name starts with `GO_` to an _Static_assert, for example:

```c
// #include <openssl/evp.h>
enum {
  GO_EVP_CTRL_GCM_SET_TAG = 0x11
}

// Translated to
#include <openssl/evp.h>
_Static_assert(EVP_CTRL_GCM_SET_TAG == 0x11) // Notice that the identifier no longer starts with GO_, it comes from evp.h!
```

Bonus feature: there is no remaining OpenSSL headers after removing all OpenSSL constants uses, so we can now build this library, to Go toolchain and any application without having to have the OpenSSL development headers installed 🎈 

PD: I've also deleted the go.mod in the checkheader package. I initially added it so this tool was not imported when vendoring the module in the Go repo, but it seems that Go is smart enough to not vendor packages which are not used. 