### PR TITLE
infra: install OpenSSL 3.0.1 in FIPS mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,17 @@ jobs:
       uses: actions/checkout@v2
     - name: Install OpenSSL - Build
       run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-build }}
-    - name: Set OpenSSL config
-      run: sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-      if: ${{ matrix.openssl-version-build == '3.0.1' }}
     - name: Check headers
       working-directory: ./cmd/checkheader
       run: go run . --ossl-include /usr/local/src/openssl-${{ matrix.openssl-version-build }}/include ../../openssl/openssl_funcs.h
       if: ${{ matrix.openssl-version-build == matrix.openssl-version-test }}
+    - name: Set OpenSSL config and prove FIPS
+      run: |
+        sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
+        go test -v -count 0 ./openssl | grep -q "FIPS enabled: true"
+      if: ${{ matrix.openssl-version-build == '3.0.1' }}
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Run Test - Build
       run: go test -v ./...
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-build }}
     - name: Set OpenSSL config
       run: cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-      if: ${{ matrix.openssl-version-build == "3.0.1" }}
+      if: ${{ matrix.openssl-version-build }} == "3.0.1"
     - name: Check headers
       working-directory: ./cmd/checkheader
       run: go run . --ossl-include /usr/local/src/openssl-${{ matrix.openssl-version-build }}/include ../../openssl/openssl_funcs.h

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - name: Install build tools
       run: sudo apt-get install -y build-essential
-    - name: Remove libssl-dev
-      run: sudo apt-get remove -y libssl-dev
     - name: Install Go
       uses: actions/setup-go@v2
       with:
@@ -23,8 +21,8 @@ jobs:
     - name: Install OpenSSL - Build
       run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-build }}
     - name: Set OpenSSL config
-      run: cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-      if: ${{ matrix.openssl-version-build }} == "3.0.1"
+      run: sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
+      if: ${{ matrix.openssl-version-build == '3.0.1' }}
     - name: Check headers
       working-directory: ./cmd/checkheader
       run: go run . --ossl-include /usr/local/src/openssl-${{ matrix.openssl-version-build }}/include ../../openssl/openssl_funcs.h

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Install OpenSSL - Build
       run: sudo sh ./scripts/openssl.sh ${{ matrix.openssl-version-build }}
+    - name: Set OpenSSL config
+      run: cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
+      if: ${{ matrix.openssl-version-build == "3.0.1" }}
     - name: Check headers
       working-directory: ./cmd/checkheader
       run: go run . --ossl-include /usr/local/src/openssl-${{ matrix.openssl-version-build }}/include ../../openssl/openssl_funcs.h

--- a/scripts/openssl-3.cnf
+++ b/scripts/openssl-3.cnf
@@ -1,0 +1,20 @@
+# Source: https://www.openssl.org/docs/man3.0/man7/fips_module.html
+
+config_diagnostics = 1
+openssl_conf = openssl_init
+
+.include /usr/local/ssl/fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+default = default_sect
+
+[default_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -11,18 +11,26 @@ case "$version" in
     "1.0.2")
         tag="OpenSSL_1_0_2u"
         sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
+        config="shared"
+        make="build_libs"
         ;;
     "1.1.0")
         tag="OpenSSL_1_1_0l"
         sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d"
+        config="shared"
+        make="build_libs"
         ;;
     "1.1.1")
         tag="OpenSSL_1_1_1m"
         sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"
+        config="shared"
+        make="build_libs"
         ;;
     "3.0.1")
         tag="openssl-3.0.1";
         sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5"
+        config="shared enable-fips"
+        make="install_fips"
         ;;
     *)
         echo >&2 "error: unsupported OpenSSL version '$version'"
@@ -39,7 +47,7 @@ rm -rf "openssl-$version"
 mv "openssl-$tag" "openssl-$version"
 
 cd "openssl-$version"
-./config shared
-make -j$(nproc) build_libs
+./config $config
+make -j$(nproc) $make
 
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"


### PR DESCRIPTION
OpenSSL 3 revamped the FIPS mode. It is no longer provided by an external module but by a built-in provider, which turns to be easy to build and install.

Additionally, after #22 landed and removed the dependency on OpenSSL development headers, it is much easier to switch between OpenSSL versions.

These two facts together allow us to build, install and use OpenSSL 3 in FIPS mode with just some minor infra modifications.