### PR TITLE
Implement one shot SHA and reduce allocs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Run Test - Build
-      run: go test -v ./...
+      run: go test -gcflags=all=-d=checkptr -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Build Test - Build

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -45,6 +45,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0
 
+// go_shaX is a SHA generic wrapper which hash p into out.
+// One shot sha functions are expected to be fast, so
+// we maximize performance by batching all cgo calls.
 static inline int
 go_shaX(GO_EVP_MD_PTR md, void *p, size_t n, void *out)
 {

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -45,6 +45,17 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0
 
+static inline int
+go_shaX(GO_EVP_MD_PTR md, void *p, size_t n, void *out)
+{
+    GO_EVP_MD_CTX_PTR ctx = go_openssl_EVP_MD_CTX_new();
+    go_openssl_EVP_DigestInit_ex(ctx, md, NULL);
+    int ret = go_openssl_EVP_DigestUpdate(ctx, p, n) &&
+        go_openssl_EVP_DigestFinal_ex(ctx, out, NULL);
+    go_openssl_EVP_MD_CTX_free(ctx);
+    return ret;
+}
+
 // These wrappers allocate out_len on the C stack to avoid having to pass a pointer from Go, which would escape to the heap.
 // Use them only in situations where the output length can be safely discarded.
 static inline int

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -258,3 +258,14 @@ func bnToBig(bn C.GO_BIGNUM_PTR) *big.Int {
 	n := C.go_openssl_BN_bn2bin(bn, base(raw))
 	return new(big.Int).SetBytes(raw[:n])
 }
+
+// noescape hides a pointer from escape analysis. noescape is
+// the identity function but escape analysis doesn't think the
+// output depends on the input. noescape is inlined and currently
+// compiles down to zero instructions.
+// USE CAREFULLY!
+//go:nosplit
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
+}

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -269,3 +269,17 @@ func noescape(p unsafe.Pointer) unsafe.Pointer {
 	x := uintptr(p)
 	return unsafe.Pointer(x ^ 0)
 }
+
+var zero byte
+
+// addr converts p to its base addr, including a noescape along the way.
+// If p is nil, addr returns a non-nil pointer, so that the result can always
+// be dereferenced.
+//
+//go:nosplit
+func addr(p []byte) *byte {
+	if len(p) == 0 {
+		return &zero
+	}
+	return (*byte)(noescape(unsafe.Pointer(&p[0])))
+}

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -17,6 +17,43 @@ import (
 	"unsafe"
 )
 
+var zero [1]byte
+
+func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) {
+	n := len(p)
+	if len(p) == 0 {
+		p = zero[:]
+	}
+	if C.go_shaX(md, noescape(unsafe.Pointer(&p[0])), C.size_t(n), noescape(unsafe.Pointer(&sum[0]))) == 0 {
+		panic("openssl: SHA failed")
+	}
+}
+
+func SHA1(p []byte) (sum [20]byte) {
+	shaX(C.go_openssl_EVP_sha1(), p, sum[:])
+	return
+}
+
+func SHA224(p []byte) (sum [28]byte) {
+	shaX(C.go_openssl_EVP_sha224(), p, sum[:])
+	return
+}
+
+func SHA256(p []byte) (sum [32]byte) {
+	shaX(C.go_openssl_EVP_sha256(), p, sum[:])
+	return
+}
+
+func SHA384(p []byte) (sum [48]byte) {
+	shaX(C.go_openssl_EVP_sha384(), p, sum[:])
+	return
+}
+
+func SHA512(p []byte) (sum [64]byte) {
+	shaX(C.go_openssl_EVP_sha512(), p, sum[:])
+	return
+}
+
 type evpHash struct {
 	md  C.GO_EVP_MD_PTR
 	ctx C.GO_EVP_MD_CTX_PTR

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -29,7 +29,7 @@ import (
 // This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
 
 func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) bool {
-	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum[:]))) != 0
+	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum))) != 0
 }
 
 func SHA1(p []byte) (sum [20]byte) {

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -48,23 +48,31 @@ func newEvpHash(ch crypto.Hash, size, blockSize int) *evpHash {
 }
 
 func (h *evpHash) finalize() {
-	C.go_openssl_EVP_MD_CTX_free(h.ctx)
-	C.go_openssl_EVP_MD_CTX_free(h.ctx2)
+	C.go_openssl_EVP_MD_CTX_free(h.noescapeCtx())
+	C.go_openssl_EVP_MD_CTX_free(h.noescapeCtx2())
+}
+
+func (h *evpHash) noescapeCtx() C.GO_EVP_MD_CTX_PTR {
+	return (C.GO_EVP_MD_CTX_PTR)(noescape(unsafe.Pointer(h.ctx)))
+}
+
+func (h *evpHash) noescapeCtx2() C.GO_EVP_MD_CTX_PTR {
+	return (C.GO_EVP_MD_CTX_PTR)(noescape(unsafe.Pointer(h.ctx2)))
 }
 
 func (h *evpHash) Reset() {
 	// There is no need to reset h.ctx2 because it is always reset after
 	// use in evpHash.sum.
-	C.go_openssl_EVP_MD_CTX_reset(h.ctx)
+	C.go_openssl_EVP_MD_CTX_reset(h.noescapeCtx())
 
-	if C.go_openssl_EVP_DigestInit_ex(h.ctx, h.md, nil) != 1 {
+	if C.go_openssl_EVP_DigestInit_ex(h.noescapeCtx(), h.md, nil) != 1 {
 		panic("openssl: EVP_DigestInit_ex failed")
 	}
 	runtime.KeepAlive(h)
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) != 1 {
+	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.noescapeCtx(), noescape(unsafe.Pointer(&p[0])), C.size_t(len(p))) != 1 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
 	runtime.KeepAlive(h)
@@ -84,14 +92,14 @@ func (h *evpHash) sum(out []byte) {
 	// that Sum has no effect on the underlying stream.
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
-	C.go_openssl_EVP_DigestInit_ex(h.ctx2, h.md, nil)
-	if C.go_openssl_EVP_MD_CTX_copy_ex(h.ctx2, h.ctx) != 1 {
+	C.go_openssl_EVP_DigestInit_ex(h.noescapeCtx2(), h.md, nil)
+	if C.go_openssl_EVP_MD_CTX_copy_ex(h.noescapeCtx2(), h.noescapeCtx()) != 1 {
 		panic("openssl: EVP_MD_CTX_copy_ex failed")
 	}
-	if C.go_openssl_EVP_DigestFinal_ex(h.ctx2, base(out), nil) != 1 {
+	if C.go_openssl_EVP_DigestFinal_ex(h.noescapeCtx2(), (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
 		panic("openssl: EVP_DigestFinal_ex failed")
 	}
-	C.go_openssl_EVP_MD_CTX_reset(h.ctx2)
+	C.go_openssl_EVP_MD_CTX_reset(h.noescapeCtx2())
 	runtime.KeepAlive(h)
 }
 

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -17,40 +17,53 @@ import (
 	"unsafe"
 )
 
-var zero [1]byte
+// NOTE: Implementation ported from https://go-review.googlesource.com/c/go/+/404295.
+// The cgo calls in this file are arranged to avoid marking the parameters as escaping.
+// To do that, we call noescape (including via addr).
+// We must also make sure that the data pointer arguments have the form unsafe.Pointer(&...)
+// so that cgo does not annotate them with cgoCheckPointer calls. If it did that, it might look
+// beyond the byte slice and find Go pointers in unprocessed parts of a larger allocation.
+// To do both of these simultaneously, the idiom is unsafe.Pointer(&*addr(p)),
+// where addr returns the base pointer of p, substituting a non-nil pointer for nil,
+// and applying a noescape along the way.
+// This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
 
-func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) {
-	n := len(p)
-	if len(p) == 0 {
-		p = zero[:]
-	}
-	if C.go_shaX(md, noescape(unsafe.Pointer(&p[0])), C.size_t(n), noescape(unsafe.Pointer(&sum[0]))) == 0 {
-		panic("openssl: SHA failed")
-	}
+func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) bool {
+	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum[:]))) != 0
 }
 
 func SHA1(p []byte) (sum [20]byte) {
-	shaX(C.go_openssl_EVP_sha1(), p, sum[:])
+	if !shaX(C.go_openssl_EVP_sha1(), p, sum[:]) {
+		panic("openssl: SHA1 failed")
+	}
 	return
 }
 
 func SHA224(p []byte) (sum [28]byte) {
-	shaX(C.go_openssl_EVP_sha224(), p, sum[:])
+	if !shaX(C.go_openssl_EVP_sha224(), p, sum[:]) {
+		panic("openssl: SHA224 failed")
+	}
 	return
 }
 
 func SHA256(p []byte) (sum [32]byte) {
-	shaX(C.go_openssl_EVP_sha256(), p, sum[:])
+	if !shaX(C.go_openssl_EVP_sha256(), p, sum[:]) {
+		panic("openssl: SHA256 failed")
+	}
 	return
 }
 
 func SHA384(p []byte) (sum [48]byte) {
-	shaX(C.go_openssl_EVP_sha384(), p, sum[:])
+	if !shaX(C.go_openssl_EVP_sha384(), p, sum[:]) {
+		panic("openssl: SHA384 failed")
+	}
 	return
 }
 
 func SHA512(p []byte) (sum [64]byte) {
-	shaX(C.go_openssl_EVP_sha512(), p, sum[:])
+	if !shaX(C.go_openssl_EVP_sha512(), p, sum[:]) {
+		panic("openssl: SHA512 failed")
+	}
 	return
 }
 
@@ -109,7 +122,7 @@ func (h *evpHash) Reset() {
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {
-	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.noescapeCtx(), noescape(unsafe.Pointer(&p[0])), C.size_t(len(p))) != 1 {
+	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) != 1 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
 	runtime.KeepAlive(h)

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -29,7 +29,7 @@ import (
 // This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
 
 func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) bool {
-	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum))) != 0
+	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), noescape(unsafe.Pointer(&sum[0]))) != 0
 }
 
 func SHA1(p []byte) (sum [20]byte) {

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -66,7 +66,7 @@ func TestSha(t *testing.T) {
 	}
 }
 
-func TestSHA1(t *testing.T) {
+func TestSHA_OneShot(t *testing.T) {
 	msg := []byte("testing")
 	var tests = []struct {
 		name string
@@ -133,4 +133,21 @@ func BenchmarkSHA256(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		SHA256(buf[:size])
 	}
+}
+
+type cgoData struct {
+	Data [16]byte
+	Ptr  *cgoData
+}
+
+func TestCgo(t *testing.T) {
+	// Test that Write does not cause cgo to scan the entire cgoData struct for pointers.
+	// The scan (if any) should be limited to the [16]byte.
+	d := new(cgoData)
+	d.Ptr = d
+	h := NewSHA256()
+	h.Write(d.Data[:])
+	h.Sum(nil)
+
+	SHA256(d.Data[:])
 }

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -66,6 +66,47 @@ func TestSha(t *testing.T) {
 	}
 }
 
+func TestSHA1(t *testing.T) {
+	msg := []byte("testing")
+	var tests = []struct {
+		name string
+		fn   func() hash.Hash
+		fn2  func([]byte) []byte
+	}{
+		{"sha1", NewSHA1, func(p []byte) []byte {
+			b := SHA1(p)
+			return b[:]
+		}},
+		{"sha224", NewSHA224, func(p []byte) []byte {
+			b := SHA224(p)
+			return b[:]
+		}},
+		{"sha256", NewSHA256, func(p []byte) []byte {
+			b := SHA256(p)
+			return b[:]
+		}},
+		{"sha384", NewSHA384, func(p []byte) []byte {
+			b := SHA384(p)
+			return b[:]
+		}},
+		{"sha512", NewSHA512, func(p []byte) []byte {
+			b := SHA512(p)
+			return b[:]
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn2(msg)
+			h := tt.fn()
+			h.Write(msg)
+			want := h.Sum(nil)
+			if !bytes.Equal(got[:], want) {
+				t.Errorf("got:%x want:%x", got, want)
+			}
+		})
+	}
+}
+
 func BenchmarkHash8Bytes(b *testing.B) {
 	b.StopTimer()
 	h := NewSHA256()
@@ -79,5 +120,17 @@ func BenchmarkHash8Bytes(b *testing.B) {
 		h.Reset()
 		h.Write(buf[:size])
 		h.Sum(sum[:0])
+	}
+}
+
+func BenchmarkSHA256(b *testing.B) {
+	b.StopTimer()
+	buf := make([]byte, 8192)
+	size := 1024
+	b.StartTimer()
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		SHA256(buf[:size])
 	}
 }


### PR DESCRIPTION
This PR contains two performance improvements which landed into `dev.boringbranch` during this development cycle, both committed in https://go-review.googlesource.com/c/go/+/395876/11.

- a99ec67c99c0e0d2bc69e495dbb0794969ec3314: Implement one shot SHA calls. This is helpful for callers which don't need to keep the hash object returned by `NewSha1` and friends, as these functions return a pointer which normally escapes in the caller side.
- 9fafecd26c83a05018bd5a64541c488c2cb247db and 31857f33f60aef96df3b40722c163ebdf13b6fc5: Makes SHA calls allocation-free by hiding openssl pointers from the escape analysis.

The benchmarks demonstrates that the new code does not allocate:

```cmd
name          old time/op    new time/op    delta
Hash8Bytes-4    4.57µs ± 4%    4.46µs ± 4%    -2.55%  (p=0.009 n=10+10)

name          old speed      new speed      delta
Hash8Bytes-4   224MB/s ± 4%   230MB/s ± 4%    +2.62%  (p=0.009 n=10+10)

name          old bytes/op   new bytes/op   delta
Hash8Bytes-4     24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
Hash8Bytes-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Removing the SHA allocations is important for when openssl is integrated into go1.19, else we would have to disable a new test that checks boring SHAs don't allocate.