### PR TITLE
Remove math/big and encoding/asn1 deps from openssl package

### DIFF
--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -26,7 +26,7 @@ func Enc(b *big.Int) openssl.BigInt {
 		return openssl.BigInt{}
 	}
 	// TODO: Use unsafe.Slice((*uint)(&x[0]), len(x)) once go1.16 is no longer supported.
-	return (*[1 << 30]uint)(unsafe.Pointer(&x[0]))[:len(x)]
+	return (*(*[]uint)(unsafe.Pointer(&x)))[:len(x)]
 }
 
 func Dec(b openssl.BigInt) *big.Int {
@@ -37,7 +37,7 @@ func Dec(b openssl.BigInt) *big.Int {
 		return new(big.Int)
 	}
 	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
-	x := (*[1 << 30]big.Word)(unsafe.Pointer(&b[0]))[:len(b)]
+	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
 	return new(big.Int).SetBits(x)
 }
 

--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 // Copyright 2022 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -10,7 +7,6 @@
 package bbig
 
 import (
-	"encoding/asn1"
 	"math/big"
 	"unsafe"
 
@@ -39,72 +35,4 @@ func Dec(b openssl.BigInt) *big.Int {
 	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
 	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
 	return new(big.Int).SetBits(x)
-}
-
-func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
-	x, y, d, err := openssl.GenerateKeyECDSA(curve)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return Dec(x), Dec(y), Dec(d), nil
-}
-
-type ecdsaSignature struct {
-	R, S *big.Int
-}
-
-func SignECDSA(priv *openssl.PrivateKeyECDSA, hash []byte) (r, s *big.Int, err error) {
-	sig, err := openssl.SignMarshalECDSA(priv, hash)
-	if err != nil {
-		return nil, nil, err
-	}
-	var esig ecdsaSignature
-	if _, err := asn1.Unmarshal(sig, &esig); err != nil {
-		return nil, nil, err
-	}
-	return esig.R, esig.S, nil
-}
-
-func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*openssl.PrivateKeyECDSA, error) {
-	return openssl.NewPrivateKeyECDSA(curve, Enc(X), Enc(Y), Enc(D))
-}
-
-func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*openssl.PublicKeyECDSA, error) {
-	return openssl.NewPublicKeyECDSA(curve, Enc(X), Enc(Y))
-}
-
-func VerifyECDSA(pub *openssl.PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
-	// We could use ECDSA_do_verify instead but would need to convert
-	// r and s to BIGNUM form. If we're going to do a conversion, marshaling
-	// to ASN.1 is more convenient and likely not much more expensive.
-	sig, err := asn1.Marshal(ecdsaSignature{r, s})
-	if err != nil {
-		return false
-	}
-	return openssl.VerifyECDSA(pub, hash, sig)
-}
-
-func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
-	bN, bE, bD, bP, bQ, bDp, bDq, bQinv, err1 := openssl.GenerateKeyRSA(bits)
-	if err1 != nil {
-		err = err1
-		return
-	}
-	N = Dec(bN)
-	E = Dec(bE)
-	D = Dec(bD)
-	P = Dec(bP)
-	Q = Dec(bQ)
-	Dp = Dec(bDp)
-	Dq = Dec(bDq)
-	Qinv = Dec(bQinv)
-	return
-}
-
-func NewPublicKeyRSA(N, E *big.Int) (*openssl.PublicKeyRSA, error) {
-	return openssl.NewPublicKeyRSA(Enc(N), Enc(E))
-}
-
-func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*openssl.PrivateKeyRSA, error) {
-	return openssl.NewPrivateKeyRSA(Enc(N), Enc(E), Enc(D), Enc(P), Enc(Q), Enc(Dp), Enc(Dq), Enc(Qinv))
 }

--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This is a mirror of crypto/internal/boring/bbig/big.go.
+
+package bbig
+
+import (
+	"encoding/asn1"
+	"math/big"
+	"unsafe"
+
+	"github.com/microsoft/go-crypto-openssl/openssl"
+)
+
+func Enc(b *big.Int) openssl.BigInt {
+	if b == nil {
+		return nil
+	}
+	x := b.Bits()
+	if len(x) == 0 {
+		return openssl.BigInt{}
+	}
+	// TODO: Use unsafe.Slice((*uint)(&x[0]), len(x)) once go1.16 is no longer supported.
+	return (*[1 << 30]uint)(unsafe.Pointer(&x[0]))[:len(x)]
+}
+
+func Dec(b openssl.BigInt) *big.Int {
+	if b == nil {
+		return nil
+	}
+	if len(b) == 0 {
+		return new(big.Int)
+	}
+	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
+	x := (*[1 << 30]big.Word)(unsafe.Pointer(&b[0]))[:len(b)]
+	return new(big.Int).SetBits(x)
+}
+
+func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
+	x, y, d, err := openssl.GenerateKeyECDSA(curve)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return Dec(x), Dec(y), Dec(d), nil
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func SignECDSA(priv *openssl.PrivateKeyECDSA, hash []byte) (r, s *big.Int, err error) {
+	sig, err := openssl.SignMarshalECDSA(priv, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	var esig ecdsaSignature
+	if _, err := asn1.Unmarshal(sig, &esig); err != nil {
+		return nil, nil, err
+	}
+	return esig.R, esig.S, nil
+}
+
+func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*openssl.PrivateKeyECDSA, error) {
+	return openssl.NewPrivateKeyECDSA(curve, Enc(X), Enc(Y), Enc(D))
+}
+
+func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*openssl.PublicKeyECDSA, error) {
+	return openssl.NewPublicKeyECDSA(curve, Enc(X), Enc(Y))
+}
+
+func VerifyECDSA(pub *openssl.PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
+	// We could use ECDSA_do_verify instead but would need to convert
+	// r and s to BIGNUM form. If we're going to do a conversion, marshaling
+	// to ASN.1 is more convenient and likely not much more expensive.
+	sig, err := asn1.Marshal(ecdsaSignature{r, s})
+	if err != nil {
+		return false
+	}
+	return openssl.VerifyECDSA(pub, hash, sig)
+}
+
+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
+	bN, bE, bD, bP, bQ, bDp, bDq, bQinv, err1 := openssl.GenerateKeyRSA(bits)
+	if err1 != nil {
+		err = err1
+		return
+	}
+	N = Dec(bN)
+	E = Dec(bE)
+	D = Dec(bD)
+	P = Dec(bP)
+	Q = Dec(bQ)
+	Dp = Dec(bDp)
+	Dq = Dec(bDq)
+	Qinv = Dec(bQinv)
+	return
+}
+
+func NewPublicKeyRSA(N, E *big.Int) (*openssl.PublicKeyRSA, error) {
+	return openssl.NewPublicKeyRSA(Enc(N), Enc(E))
+}
+
+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*openssl.PrivateKeyRSA, error) {
+	return openssl.NewPrivateKeyRSA(Enc(N), Enc(E), Enc(D), Enc(P), Enc(Q), Enc(Dp), Enc(Dq), Enc(Qinv))
+}

--- a/openssl/bbig/bridge/bridge.go
+++ b/openssl/bbig/bridge/bridge.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// These wrappers only exist for code reuse in places where we need the old pre-go1.19 signature.
+
+package bbig
+
+import (
+	"encoding/asn1"
+	"math/big"
+
+	"github.com/microsoft/go-crypto-openssl/openssl"
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig"
+)
+
+func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
+	x, y, d, err := openssl.GenerateKeyECDSA(curve)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return bbig.Dec(x), bbig.Dec(y), bbig.Dec(d), nil
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func SignECDSA(priv *openssl.PrivateKeyECDSA, hash []byte) (r, s *big.Int, err error) {
+	sig, err := openssl.SignMarshalECDSA(priv, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	var esig ecdsaSignature
+	if _, err := asn1.Unmarshal(sig, &esig); err != nil {
+		return nil, nil, err
+	}
+	return esig.R, esig.S, nil
+}
+
+func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*openssl.PrivateKeyECDSA, error) {
+	return openssl.NewPrivateKeyECDSA(curve, bbig.Enc(X), bbig.Enc(Y), bbig.Enc(D))
+}
+
+func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*openssl.PublicKeyECDSA, error) {
+	return openssl.NewPublicKeyECDSA(curve, bbig.Enc(X), bbig.Enc(Y))
+}
+
+func VerifyECDSA(pub *openssl.PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
+	sig, err := asn1.Marshal(ecdsaSignature{r, s})
+	if err != nil {
+		return false
+	}
+	return openssl.VerifyECDSA(pub, hash, sig)
+}
+
+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
+	bN, bE, bD, bP, bQ, bDp, bDq, bQinv, err1 := openssl.GenerateKeyRSA(bits)
+	if err1 != nil {
+		err = err1
+		return
+	}
+	N = bbig.Dec(bN)
+	E = bbig.Dec(bE)
+	D = bbig.Dec(bD)
+	P = bbig.Dec(bP)
+	Q = bbig.Dec(bQ)
+	Dp = bbig.Dec(bDp)
+	Dq = bbig.Dec(bDq)
+	Qinv = bbig.Dec(bQinv)
+	return
+}
+
+func NewPublicKeyRSA(N, E *big.Int) (*openssl.PublicKeyRSA, error) {
+	return openssl.NewPublicKeyRSA(bbig.Enc(N), bbig.Enc(E))
+}
+
+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*openssl.PrivateKeyRSA, error) {
+	return openssl.NewPrivateKeyRSA(
+		bbig.Enc(N), bbig.Enc(E), bbig.Enc(D),
+		bbig.Enc(P), bbig.Enc(Q),
+		bbig.Enc(Dp), bbig.Enc(Dq), bbig.Enc(Qinv),
+	)
+}

--- a/openssl/bbig/bridge/bridge.go
+++ b/openssl/bbig/bridge/bridge.go
@@ -3,7 +3,7 @@
 
 // These wrappers only exist for code reuse in places where we need the old pre-go1.19 signature.
 
-package bbig
+package bridge
 
 import (
 	"encoding/asn1"

--- a/openssl/ecdsa_test.go
+++ b/openssl/ecdsa_test.go
@@ -11,7 +11,7 @@ import (
 	"crypto/elliptic"
 	"testing"
 
-	"github.com/microsoft/go-crypto-openssl/openssl/bbig"
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig/bridge"
 )
 
 func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
@@ -57,32 +57,32 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 		t.Fatal(err)
 	}
 
-	priv, err := bbig.NewPrivateKeyECDSA(key.Params().Name, key.X, key.Y, key.D)
+	priv, err := bridge.NewPrivateKeyECDSA(key.Params().Name, key.X, key.Y, key.D)
 	if err != nil {
 		t.Fatal(err)
 	}
 	hashed := []byte("testing")
-	r, s, err := bbig.SignECDSA(priv, hashed)
+	r, s, err := bridge.SignECDSA(priv, hashed)
 	if err != nil {
 		t.Errorf("error signing: %s", err)
 		return
 	}
 
-	pub, err := bbig.NewPublicKeyECDSA(key.Params().Name, key.X, key.Y)
+	pub, err := bridge.NewPublicKeyECDSA(key.Params().Name, key.X, key.Y)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bbig.VerifyECDSA(pub, hashed, r, s) {
+	if !bridge.VerifyECDSA(pub, hashed, r, s) {
 		t.Errorf("Verify failed")
 	}
 	hashed[0] ^= 0xff
-	if bbig.VerifyECDSA(pub, hashed, r, s) {
+	if bridge.VerifyECDSA(pub, hashed, r, s) {
 		t.Errorf("Verify succeeded despite intentionally invalid hash!")
 	}
 }
 
 func generateKeycurve(c elliptic.Curve) (*ecdsa.PrivateKey, error) {
-	x, y, d, err := bbig.GenerateKeyECDSA(c.Params().Name)
+	x, y, d, err := bridge.GenerateKeyECDSA(c.Params().Name)
 	if err != nil {
 		return nil, err
 	}

--- a/openssl/ecdsa_test.go
+++ b/openssl/ecdsa_test.go
@@ -4,12 +4,14 @@
 //go:build linux && !android
 // +build linux,!android
 
-package openssl
+package openssl_test
 
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"testing"
+
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig"
 )
 
 func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
@@ -55,32 +57,32 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 		t.Fatal(err)
 	}
 
-	priv, err := NewPrivateKeyECDSA(key.Params().Name, key.X, key.Y, key.D)
+	priv, err := bbig.NewPrivateKeyECDSA(key.Params().Name, key.X, key.Y, key.D)
 	if err != nil {
 		t.Fatal(err)
 	}
 	hashed := []byte("testing")
-	r, s, err := SignECDSA(priv, hashed)
+	r, s, err := bbig.SignECDSA(priv, hashed)
 	if err != nil {
 		t.Errorf("error signing: %s", err)
 		return
 	}
 
-	pub, err := NewPublicKeyECDSA(key.Params().Name, key.X, key.Y)
+	pub, err := bbig.NewPublicKeyECDSA(key.Params().Name, key.X, key.Y)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !VerifyECDSA(pub, hashed, r, s) {
+	if !bbig.VerifyECDSA(pub, hashed, r, s) {
 		t.Errorf("Verify failed")
 	}
 	hashed[0] ^= 0xff
-	if VerifyECDSA(pub, hashed, r, s) {
+	if bbig.VerifyECDSA(pub, hashed, r, s) {
 		t.Errorf("Verify succeeded despite intentionally invalid hash!")
 	}
 }
 
 func generateKeycurve(c elliptic.Curve) (*ecdsa.PrivateKey, error) {
-	x, y, d, err := GenerateKeyECDSA(c.Params().Name)
+	x, y, d, err := bbig.GenerateKeyECDSA(c.Params().Name)
 	if err != nil {
 		return nil, err
 	}

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/go-crypto-openssl/openssl"
-	"github.com/microsoft/go-crypto-openssl/openssl/bbig"
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig/bridge"
 )
 
 func TestRSAKeyGeneration(t *testing.T) {
@@ -134,15 +134,15 @@ func TestSignVerifyRSAPSS(t *testing.T) {
 
 func newRSAKey(t *testing.T, size int) (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
 	t.Helper()
-	N, E, D, P, Q, Dp, Dq, Qinv, err := bbig.GenerateKeyRSA(size)
+	N, E, D, P, Q, Dp, Dq, Qinv, err := bridge.GenerateKeyRSA(size)
 	if err != nil {
 		t.Fatalf("GenerateKeyRSA(%d): %v", size, err)
 	}
-	priv, err := bbig.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
+	priv, err := bridge.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
 	if err != nil {
 		t.Fatalf("NewPrivateKeyRSA(%d): %v", size, err)
 	}
-	pub, err := bbig.NewPublicKeyRSA(N, E)
+	pub, err := bridge.NewPublicKeyRSA(N, E)
 	if err != nil {
 		t.Fatalf("NewPublicKeyRSA(%d): %v", size, err)
 	}
@@ -161,7 +161,7 @@ func BenchmarkEncryptRSAPKCS1(b *testing.B) {
 	b.StopTimer()
 	// Public key length should be at least of 2048 bits, else OpenSSL will report an error when running in FIPS mode.
 	n := fromBase36("14314132931241006650998084889274020608918049032671858325988396851334124245188214251956198731333464217832226406088020736932173064754214329009979944037640912127943488972644697423190955557435910767690712778463524983667852819010259499695177313115447116110358524558307947613422897787329221478860907963827160223559690523660574329011927531289655711860504630573766609239332569210831325633840174683944553667352219670930408593321661375473885147973879086994006440025257225431977751512374815915392249179976902953721486040787792801849818254465486633791826766873076617116727073077821584676715609985777563958286637185868165868520557")
-	test2048PubKey, err := bbig.NewPublicKeyRSA(n, big.NewInt(3))
+	test2048PubKey, err := bridge.NewPublicKeyRSA(n, big.NewInt(3))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func BenchmarkEncryptRSAPKCS1(b *testing.B) {
 func BenchmarkGenerateKeyRSA(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, _, _, _, _, _, _, _, err := bbig.GenerateKeyRSA(2048)
+		_, _, _, _, _, _, _, _, err := bridge.GenerateKeyRSA(2048)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -4,7 +4,7 @@
 //go:build linux && !android
 // +build linux,!android
 
-package openssl
+package openssl_test
 
 import (
 	"bytes"
@@ -12,6 +12,9 @@ import (
 	"math/big"
 	"strconv"
 	"testing"
+
+	"github.com/microsoft/go-crypto-openssl/openssl"
+	"github.com/microsoft/go-crypto-openssl/openssl/bbig"
 )
 
 func TestRSAKeyGeneration(t *testing.T) {
@@ -20,11 +23,11 @@ func TestRSAKeyGeneration(t *testing.T) {
 			t.Parallel()
 			priv, pub := newRSAKey(t, size)
 			msg := []byte("hi!")
-			enc, err := EncryptRSAPKCS1(pub, msg)
+			enc, err := openssl.EncryptRSAPKCS1(pub, msg)
 			if err != nil {
 				t.Fatalf("EncryptPKCS1v15: %v", err)
 			}
-			dec, err := DecryptRSAPKCS1(priv, enc)
+			dec, err := openssl.DecryptRSAPKCS1(priv, enc)
 			if err != nil {
 				t.Fatalf("DecryptPKCS1v15: %v", err)
 			}
@@ -36,15 +39,15 @@ func TestRSAKeyGeneration(t *testing.T) {
 }
 
 func TestEncryptDecryptOAEP(t *testing.T) {
-	sha256 := NewSHA256()
+	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	label := []byte("ho!")
 	priv, pub := newRSAKey(t, 2048)
-	enc, err := EncryptRSAOAEP(sha256, pub, msg, label)
+	enc, err := openssl.EncryptRSAOAEP(sha256, pub, msg, label)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dec, err := DecryptRSAOAEP(sha256, priv, enc, label)
+	dec, err := openssl.DecryptRSAOAEP(sha256, priv, enc, label)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,14 +57,14 @@ func TestEncryptDecryptOAEP(t *testing.T) {
 }
 
 func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
-	sha256 := NewSHA256()
+	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
-	enc, err := EncryptRSAOAEP(sha256, pub, msg, []byte("ho!"))
+	enc, err := openssl.EncryptRSAOAEP(sha256, pub, msg, []byte("ho!"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	dec, err := DecryptRSAOAEP(sha256, priv, enc, []byte("wrong!"))
+	dec, err := openssl.DecryptRSAOAEP(sha256, priv, enc, []byte("wrong!"))
 	if err == nil {
 		t.Errorf("error expected")
 	}
@@ -71,15 +74,15 @@ func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
 }
 
 func TestSignVerifyPKCS1v15(t *testing.T) {
-	sha256 := NewSHA256()
+	sha256 := openssl.NewSHA256()
 	priv, pub := newRSAKey(t, 2048)
 	sha256.Write([]byte("hi!"))
 	hashed := sha256.Sum(nil)
-	signed, err := SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
+	signed, err := openssl.SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VerifyRSAPKCS1v15(pub, crypto.SHA256, hashed, signed)
+	err = openssl.VerifyRSAPKCS1v15(pub, crypto.SHA256, hashed, signed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,58 +91,58 @@ func TestSignVerifyPKCS1v15(t *testing.T) {
 func TestSignVerifyPKCS1v15_Unhashed(t *testing.T) {
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
-	signed, err := SignRSAPKCS1v15(priv, 0, msg)
+	signed, err := openssl.SignRSAPKCS1v15(priv, 0, msg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VerifyRSAPKCS1v15(pub, 0, msg, signed)
+	err = openssl.VerifyRSAPKCS1v15(pub, 0, msg, signed)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
-	sha256 := NewSHA256()
+	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
 	sha256.Write(msg)
 	hashed := sha256.Sum(nil)
-	signed, err := SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
+	signed, err := openssl.SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VerifyRSAPKCS1v15(pub, crypto.SHA256, msg, signed)
+	err = openssl.VerifyRSAPKCS1v15(pub, crypto.SHA256, msg, signed)
 	if err == nil {
 		t.Fatal("error expected")
 	}
 }
 
 func TestSignVerifyRSAPSS(t *testing.T) {
-	sha256 := NewSHA256()
+	sha256 := openssl.NewSHA256()
 	priv, pub := newRSAKey(t, 2048)
 	sha256.Write([]byte("testing"))
 	hashed := sha256.Sum(nil)
-	signed, err := SignRSAPSS(priv, crypto.SHA256, hashed, 0)
+	signed, err := openssl.SignRSAPSS(priv, crypto.SHA256, hashed, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, 0)
+	err = openssl.VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func newRSAKey(t *testing.T, size int) (*PrivateKeyRSA, *PublicKeyRSA) {
+func newRSAKey(t *testing.T, size int) (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
 	t.Helper()
-	N, E, D, P, Q, Dp, Dq, Qinv, err := GenerateKeyRSA(size)
+	N, E, D, P, Q, Dp, Dq, Qinv, err := bbig.GenerateKeyRSA(size)
 	if err != nil {
 		t.Fatalf("GenerateKeyRSA(%d): %v", size, err)
 	}
-	priv, err := NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
+	priv, err := bbig.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
 	if err != nil {
 		t.Fatalf("NewPrivateKeyRSA(%d): %v", size, err)
 	}
-	pub, err := NewPublicKeyRSA(N, E)
+	pub, err := bbig.NewPublicKeyRSA(N, E)
 	if err != nil {
 		t.Fatalf("NewPublicKeyRSA(%d): %v", size, err)
 	}
@@ -158,14 +161,24 @@ func BenchmarkEncryptRSAPKCS1(b *testing.B) {
 	b.StopTimer()
 	// Public key length should be at least of 2048 bits, else OpenSSL will report an error when running in FIPS mode.
 	n := fromBase36("14314132931241006650998084889274020608918049032671858325988396851334124245188214251956198731333464217832226406088020736932173064754214329009979944037640912127943488972644697423190955557435910767690712778463524983667852819010259499695177313115447116110358524558307947613422897787329221478860907963827160223559690523660574329011927531289655711860504630573766609239332569210831325633840174683944553667352219670930408593321661375473885147973879086994006440025257225431977751512374815915392249179976902953721486040787792801849818254465486633791826766873076617116727073077821584676715609985777563958286637185868165868520557")
-	test2048PubKey, err := NewPublicKeyRSA(n, big.NewInt(3))
+	test2048PubKey, err := bbig.NewPublicKeyRSA(n, big.NewInt(3))
 	if err != nil {
 		b.Fatal(err)
 	}
 	b.StartTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := EncryptRSAPKCS1(test2048PubKey, []byte("testing")); err != nil {
+		if _, err := openssl.EncryptRSAPKCS1(test2048PubKey, []byte("testing")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGenerateKeyRSA(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, _, _, _, _, err := bbig.GenerateKeyRSA(2048)
+		if err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This PR is a mirror of https://github.com/golang/go/commit/9e9c7a0aec0f821b54006681d4fdfba8a0cd6679.

`go1.19` has removed `math/big` and `encoding/asn1` dependencies from `boring` and moved into `boring/bbig`. They argue that low-level crypto stuff should not depend on those. See the upstream commit for more info.

With this change, `go-crypto-openssl` will be in good shape for integrating it into go1.19.