### PR TITLE
Move BigInt to its own file

### DIFF
--- a/openssl/big.go
+++ b/openssl/big.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package openssl
+
+// This file does not have build constraints to
+// facilitate using BigInt in Go crypto.
+// Go crypto references BigInt unconditionally,
+// even if it is not finally used.
+
+// A BigInt is the raw words from a BigInt.
+// This definition allows us to avoid importing math/big.
+// Conversion between BigInt and *big.Int is in openssl/bbig.
+type BigInt []uint

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -21,11 +21,6 @@ import (
 	"unsafe"
 )
 
-// A BigInt is the raw words from a BigInt.
-// This definition allows us to avoid importing math/big.
-// Conversion between BigInt and *big.Int is in openssl/bbig.
-type BigInt []uint
-
 var (
 	providerNameFips    = C.CString("fips")
 	providerNameDefault = C.CString("default")


### PR DESCRIPTION
Go crypto references `boring.BigInt` unconditionally, even if it is not finally used.  To do so, it is placed in a file without build constraints.

We should do the same, else Go compilation fails.