### PR TITLE
Promote NewGCMTLS as top-level function

### DIFF
--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -296,8 +296,8 @@ func (c *aesCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
 	return c.newGCM(false)
 }
 
-// NewGCMTLS returns a GCM cipher which is specific to TLS
-// and should not be used outside of that context.
+// NewGCMTLS returns a GCM cipher specific to TLS
+// and should not be used for non-TLS purposes.
 func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
 	return c.(*aesCipher).NewGCMTLS()
 }

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -296,6 +296,12 @@ func (c *aesCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
 	return c.newGCM(false)
 }
 
+// NewGCMTLS returns a GCM cipher which is specific to TLS
+// and should not be used outside of that context.
+func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
+	return c.(*aesCipher).NewGCMTLS()
+}
+
 func (c *aesCipher) NewGCMTLS() (cipher.AEAD, error) {
 	return c.newGCM(true)
 }

--- a/openssl/aes_test.go
+++ b/openssl/aes_test.go
@@ -67,8 +67,7 @@ func TestSealAndOpenTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := ci.(*aesCipher)
-	gcm, err := c.NewGCMTLS()
+	gcm, err := NewGCMTLS(ci)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Upstream has added `NewGCMTLS` function to the `boring` package in go1.19, so we have to provide it too.

See https://github.com/microsoft/go/pull/596#issuecomment-1154226511 for a detailed description of this issue.

Once this is merged, we can change https://github.com/microsoft/go/pull/597 so it uses the new function instead of implementing a translation layer in the patch file.