### PR TITLE
Reduce SHA cgo calls

### DIFF
--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -144,12 +144,15 @@ DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (GO_OSSL_LIB_CTX_PTR
 DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, const char *propq), (libctx, propq)) \
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
+DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
+DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, GO_EVP_MD_CTX_PTR in), (out, in)) \
 DEFINEFUNC_RENAMED_1_1(int, EVP_MD_CTX_reset, EVP_MD_CTX_cleanup, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_md5, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -152,7 +152,7 @@ DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsi
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
-DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, GO_EVP_MD_CTX_PTR in), (out, in)) \
+DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 DEFINEFUNC_RENAMED_1_1(int, EVP_MD_CTX_reset, EVP_MD_CTX_cleanup, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_md5, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -105,10 +105,8 @@ func (h *evpHash) finalize() {
 func (h *evpHash) Reset() {
 	// There is no need to reset h.ctx2 because it is always reset after
 	// use in evpHash.sum.
-	C.go_openssl_EVP_MD_CTX_reset(h.ctx)
-
-	if C.go_openssl_EVP_DigestInit_ex(h.ctx, h.md, nil) != 1 {
-		panic("openssl: EVP_DigestInit_ex failed")
+	if C.go_openssl_EVP_DigestInit(h.ctx, h.md) != 1 {
+		panic("openssl: EVP_DigestInit failed")
 	}
 	runtime.KeepAlive(h)
 }
@@ -134,14 +132,12 @@ func (h *evpHash) sum(out []byte) {
 	// that Sum has no effect on the underlying stream.
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
-	C.go_openssl_EVP_DigestInit_ex(h.ctx2, h.md, nil)
-	if C.go_openssl_EVP_MD_CTX_copy_ex(h.ctx2, h.ctx) != 1 {
-		panic("openssl: EVP_MD_CTX_copy_ex failed")
+	if C.go_openssl_EVP_MD_CTX_copy(h.ctx2, h.ctx) != 1 {
+		panic("openssl: EVP_MD_CTX_copy failed")
 	}
-	if C.go_openssl_EVP_DigestFinal_ex(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
-		panic("openssl: EVP_DigestFinal_ex failed")
+	if C.go_openssl_EVP_DigestFinal(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
+		panic("openssl: EVP_DigestFinal failed")
 	}
-	C.go_openssl_EVP_MD_CTX_reset(h.ctx2)
 	runtime.KeepAlive(h)
 }
 


### PR DESCRIPTION
We are using the `*_ex` variant of several OpenSSL functions which cause us more harm than good in terms of performance:
- `EVP_MD_CTX_copy_ex` requires an initialized context, but we always have an uninitialized context at that point, so we have to call `EVP_DigestInit_ex` before it. On the other hand, `EVP_MD_CTX_copy` initializes the context for us in one call.
- `EVP_DigestInit_ex` does not reset the context, but `EVP_DigestInit` does, so we can avoid calling `EVP_MD_CTX_reset` on our side.
- `EVP_DigestFinal_ex` does not reset the context, but `EVP_DigestFinal` does, so we can avoid calling `EVP_MD_CTX_reset` on our side.

Taking into account that each cgo call overhead is ~80ns, getting rid of 3 cgo calls can make a difference when hashing small messages:

```cmd
name          old time/op    new time/op    delta
Hash8Bytes-4    1.93µs ± 1%    1.23µs ± 3%  -36.46%  (p=0.000 n=9+10)

name          old speed      new speed      delta
Hash8Bytes-4  4.14MB/s ± 1%  6.51MB/s ± 3%  +57.38%  (p=0.000 n=9+10)

name          old memory/op   new memory/op   delta
Hash8Bytes-4     0.00B          0.00B          ~     (all equal)

name          old allocs/op  new allocs/op  delta
Hash8Bytes-4      0.00           0.00          ~     (all equal)
```