### PR TITLE
Initialize empty AES-GCM inputs

### DIFF
--- a/openssl/aes_test.go
+++ b/openssl/aes_test.go
@@ -61,6 +61,28 @@ func TestSealAndOpen(t *testing.T) {
 	}
 }
 
+func TestSealAndOpen_Empty(t *testing.T) {
+	key := []byte("D249BF6DEC97B1EBD69BC4D6B3A3C49D")
+	ci, err := NewAESCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := ci.(*aesCipher)
+	gcm, err := c.NewGCM(gcmStandardNonceSize, gcmTagSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := []byte{0x91, 0xc7, 0xa7, 0x54, 0x52, 0xef, 0x10, 0xdb, 0x91, 0xa8, 0x6c, 0xf9}
+	sealed := gcm.Seal(nil, nonce, []byte{}, []byte{})
+	decrypted, err := gcm.Open(nil, nonce, sealed, []byte{})
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(decrypted, plainText) {
+		t.Errorf("unexpected decrypted result\ngot: %#v\nexp: %#v", decrypted, plainText)
+	}
+}
+
 func TestSealAndOpenTLS(t *testing.T) {
 	key := []byte("D249BF6DEC97B1EBD69BC4D6B3A3C49D")
 	ci, err := NewAESCipher(key)

--- a/openssl/aes_test.go
+++ b/openssl/aes_test.go
@@ -78,8 +78,8 @@ func TestSealAndOpen_Empty(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !bytes.Equal(decrypted, plainText) {
-		t.Errorf("unexpected decrypted result\ngot: %#v\nexp: %#v", decrypted, plainText)
+	if !bytes.Equal(decrypted, []byte{}) {
+		t.Errorf("unexpected decrypted result\ngot: %#v\nexp: %#v", decrypted, []byte{})
 	}
 }
 

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -91,13 +91,16 @@ go_openssl_EVP_CIPHER_CTX_seal_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        unsigned char *out,
                                        const unsigned char *nonce,
                                        const unsigned char *in, int in_len,
-                                       const unsigned char *add, int add_len)
+                                       const unsigned char *aad, int aad_len)
 {
+    if (in_len == 0) in = "";
+    if (aad_len == 0) aad = "";
+
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_ENCRYPT) != 1)
         return 0;
 
     int discard_len, out_len;
-    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
+    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
         || go_openssl_EVP_EncryptUpdate(ctx, out, &out_len, in, in_len) != 1
         || go_openssl_EVP_EncryptFinal_ex(ctx, out + out_len, &discard_len) != 1)
     {
@@ -115,14 +118,17 @@ go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        unsigned char *out,
                                        const unsigned char *nonce,
                                        const unsigned char *in, int in_len,
-                                       const unsigned char *add, int add_len,
+                                       const unsigned char *aad, int aad_len,
                                        const unsigned char *tag)
 {
+    if (in_len == 0) in = "";
+    if (aad_len == 0) aad = "";
+
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_DECRYPT) != 1)
         return 0;
 
     int discard_len, out_len;
-    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, add, add_len) != 1
+    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
         || go_openssl_EVP_DecryptUpdate(ctx, out, &out_len, in, in_len) != 1)
     {
         return 0;


### PR DESCRIPTION
This PR ensures AES-GCM seal and open empty inputs are initialized.

Uninitialized inputs did not trigger any test failure until now because most of OpenSSL compilations seem to handle them correctly.

Strangely, the OpenSSL binary packed in `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b` can't handle them, even though it uses OpenSSL 1.1.1, which causes [this failure](https://dev.azure.com/dnceng/public/_build/results?buildId=1904417&view=ms.vss-test-web.build-test-results-tab&runId=49510102&resultId=102949&paneView=debug) when running Go crypto tests.

I found this now thanks to https://github.com/microsoft/go/pull/655, which forces the OpenSSL backend even if FIPS is not enabled.