### PR TITLE
[v0.1] free HMAC context when it is garbage collected

### DIFF
--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -45,6 +45,7 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		key:       hkey,
 		ctx:       hmacCtxNew(),
 	}
+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 	hmac.Reset()
 	return hmac
 }


### PR DESCRIPTION
Cherry-pick #38 to v0.1 so the fix can be backported to go1.18.
 
(cherry picked from commit 066097424794ede74ef161c68b36f18b44dc6cb8)