### PR TITLE
Fix use-after-free and double-free bugs on ECDH keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,10 @@ jobs:
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Run Test - Build
-      run: go test -gcflags=all=-d=checkptr -v ./...
+      # Run each test 10 times so the garbage collector chimes in 
+      # and exercises the multiple finalizers we use.
+      # This can detect uses-after-free and double-free issues.
+      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}
     - name: Build Test - Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run Test - Build
       # Run each test 10 times so the garbage collector chimes in 
       # and exercises the multiple finalizers we use.
-      # This can detect uses-after-free and double-free issues.
+      # This can detect use-after-free and double-free issues.
       run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version-build }}

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -17,10 +17,10 @@ type PublicKeyECDH struct {
 	_pkey C.GO_EVP_PKEY_PTR
 	bytes []byte
 
-	// priv is only set when _pkey is derived from a private key,
-	// in which case the private key is responsible of freeing _pkey.
-	// This also ensures that priv is not finalized meanwhile
-	// the public key is alive.
+	// priv is only set when PublicKeyECDH is derived from a private key,
+	// in which case priv's finalizer is responsible for freeing _pkey.
+	// This ensures priv is not finalized while the public key is alive,
+	// which could cause use-after-free and double-free behavior.
 	//
 	// We could avoid this altogether if using EVP_PKEY_up_ref
 	// when instantiating a derived public key, unfortunately

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -16,10 +16,22 @@ import (
 type PublicKeyECDH struct {
 	_pkey C.GO_EVP_PKEY_PTR
 	bytes []byte
+
+	// priv is only set when _pkey is derived from a private key,
+	// in which case the private key is responsible of freeing _pkey.
+	// This also ensures that priv is not finalized meanwhile
+	// the public key is alive.
+	//
+	// We could avoid this altogether if using EVP_PKEY_up_ref
+	// when instantiating a derived public key, unfortunately
+	// it is not available on OpenSSL 1.0.2.
+	priv *PrivateKeyECDH
 }
 
 func (k *PublicKeyECDH) finalize() {
-	C.go_openssl_EVP_PKEY_free(k._pkey)
+	if k.priv == nil {
+		C.go_openssl_EVP_PKEY_free(k._pkey)
+	}
 }
 
 type PrivateKeyECDH struct {
@@ -72,7 +84,7 @@ func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 	if err != nil {
 		return nil, err
 	}
-	k = &PublicKeyECDH{pkey, append([]byte(nil), bytes...)}
+	k = &PublicKeyECDH{pkey, append([]byte(nil), bytes...), nil}
 	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
 	return k, nil
 }
@@ -149,7 +161,7 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 	if int(n) != len(bytes) {
 		return nil, newOpenSSLError("EC_POINT_point2oct")
 	}
-	pub := &PublicKeyECDH{k._pkey, bytes}
+	pub := &PublicKeyECDH{k._pkey, bytes, k}
 	// Note: Same as in NewPublicKeyECDH regarding finalizer and KeepAlive.
 	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 	return pub, nil


### PR DESCRIPTION
This PR fixes a couple of memory issues produced when calling `PrivateKeyECDH.PublicKey()`.

The underlying problem is that this method creates a public key that shares the same OpenSSL EVP_PKEY instance with the private key. This EVP_KEY is freed when any of the keys is garbage collected, leaving the other key with an invalid EVP_PKEY that will probably crash the application when it is used.

I've also improved the test pipeline so it has more chances to detect this memory bugs.