### PR TITLE
sha: add WriteString and WriteByte method

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG VARIANT=1.17-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/go:0-${VARIANT}
 
 RUN apt-get update \
     && apt-get install -y build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,9 @@
 		"GO_OPENSSL_VERSION_OVERRIDE": "1.1.0",
 	},
 	"onCreateCommand": "sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}",
-	"extensions": [
-		"golang.go"
-	]
+	"customizations": {
+		"vscode": {
+			"extensions": ["golang.go"]
+		}
+	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/microsoft/go-crypto-openssl
 
-go 1.16
+go 1.17

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -119,6 +119,26 @@ func (h *evpHash) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func (h *evpHash) WriteString(s string) (int, error) {
+	// TODO: use unsafe.StringData once we drop support
+	// for go1.19 and earlier.
+	hdr := (*struct {
+		Data *byte
+		Len  int
+	})(unsafe.Pointer(&s))
+	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(hdr.Data), C.size_t(len(s))) == 0 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	return len(s), nil
+}
+
+func (h *evpHash) WriteByte(c byte) error {
+	if C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1) == 0 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	return nil
+}
+
 func (h *evpHash) Size() int {
 	return h.size
 }

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding"
 	"hash"
+	"io"
 	"testing"
 )
 
@@ -57,6 +58,23 @@ func TestSha(t *testing.T) {
 				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
 			}
 
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			bw := h.(io.ByteWriter)
+			for i := 0; i < len(msg); i++ {
+				bw.WriteByte(msg[i])
+			}
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			h.(io.StringWriter).WriteString(string(msg))
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {


### PR DESCRIPTION
This PR implements `WriteString` and `WriteByte` for all supported hashers. These methods will be required by the boring API in go1.21.

See [CL 483816](https://go-review.googlesource.com/c/go/+/483816), [483815](https://go-review.googlesource.com/c/go/+/483815), and [CL 481478](https://go-review.googlesource.com/c/go/+/481478).