### PR TITLE
simplify devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,0 @@
-ARG VARIANT=1.17-bullseye
-FROM mcr.microsoft.com/devcontainers/go:0-${VARIANT}
-
-RUN apt-get update \
-    && apt-get install -y build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,19 +2,18 @@
 
 {
 	"name": "Go",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			"VARIANT": "1.17-bullseye",
-		}
-	},
 	"containerEnv": {
-		"GO_OPENSSL_VERSION_OVERRIDE": "1.1.0",
+		"GO_OPENSSL_VERSION_OVERRIDE": "1.1.1"
 	},
-	"onCreateCommand": "sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {}
+	},
+	"onCreateCommand": "sudo sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}",
 	"customizations": {
 		"vscode": {
-			"extensions": ["golang.go"]
+			"extensions": [
+				"golang.go"
+			]
 		}
-	},
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,5 @@
 	"features": {
 		"ghcr.io/devcontainers/features/go:1": {}
 	},
-	"onCreateCommand": "sudo sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"golang.go"
-			]
-		}
-	}
+	"onCreateCommand": "sudo sh ${containerWorkspaceFolder}/scripts/openssl.sh ${GO_OPENSSL_VERSION_OVERRIDE}"
 }

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -13,24 +13,28 @@ case "$version" in
         sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "1.1.0")
         tag="OpenSSL_1_1_0l"
         sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "1.1.1")
         tag="OpenSSL_1_1_1m"
         sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "3.0.1")
         tag="openssl-3.0.1";
         sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5"
-        config="shared enable-fips"
-        make="install_fips"
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
         ;;
     *)
         echo >&2 "error: unsupported OpenSSL version '$version'"
@@ -49,5 +53,8 @@ mv "openssl-$tag" "openssl-$version"
 cd "openssl-$version"
 ./config $config
 make -j$(nproc) $make
+if [ -n "$install" ]; then
+    make $install
+fi
 
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"


### PR DESCRIPTION
There is no need for an external Dockerfile when using:
```
"features": {
	"ghcr.io/devcontainers/features/go:1": {}
},
```