### PR TITLE
hmac: fix memory leak in NewHMAC

### DIFF
--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -210,6 +210,7 @@ func (h *hmac3) Reset() {
 }
 
 func (h *hmac3) finalize() {
+	C.go_openssl_EVP_MAC_free(h.md)
 	if h.ctx == nil {
 		return
 	}

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -279,6 +279,7 @@ DEFINEFUNC(int, EVP_PKEY_derive_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_PKEY_derive_set_peer, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR peer), (ctx, peer)) \
 DEFINEFUNC(int, EVP_PKEY_derive, (GO_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen), (ctx, key, keylen)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
+DEFINEFUNC_3_0(void, EVP_MAC_free, (GO_EVP_MAC_PTR mac), (mac)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
 DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_dup, (const GO_EVP_MAC_CTX_PTR arg0), (arg0)) \


### PR DESCRIPTION
When using OpenSSL 3, `NewHMAC` calls [EVP_MAC_fetch](https://www.openssl.org/docs/man3.0/man3/EVP_MAC_fetch.html) and doesn't free the returned object, which should be done calling [EVP_MAC_free](https://www.openssl.org/docs/man3.0/man3/EVP_MAC_free.html).

Seen while working on https://github.com/golang-fips/openssl/pull/77.