### PR TITLE
sha: Add SHA3 implementation

### DIFF
--- a/openssl/evpkey.go
+++ b/openssl/evpkey.go
@@ -57,6 +57,26 @@ func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {
 		return C.go_openssl_EVP_sha384()
 	case crypto.SHA512:
 		return C.go_openssl_EVP_sha512()
+	case crypto.SHA3_224:
+		if vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_224()
+	case crypto.SHA3_256:
+		if vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_256()
+	case crypto.SHA3_384:
+		if vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_384()
+	case crypto.SHA3_512:
+		if vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_512()
 	}
 	return nil
 }

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -10,8 +10,9 @@
 int go_openssl_fips_enabled(void* handle);
 int go_openssl_version_major(void* handle);
 int go_openssl_version_minor(void* handle);
+int go_openssl_version_feature(void* handle);
 int go_openssl_thread_setup(void);
-void go_openssl_load_functions(void* handle, int major, int minor);
+void go_openssl_load_functions(void* handle, int major, int minor, int feature);
 
 // Define pointers to all the used OpenSSL functions.
 // Calling C function pointers from Go is currently not supported.
@@ -29,6 +30,8 @@ void go_openssl_load_functions(void* handle, int major, int minor);
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_1_1_1(ret, func, args, argscall)     \
+    DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_3_0(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall)     \
@@ -42,6 +45,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_1_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0

--- a/openssl/openssl_funcs.h
+++ b/openssl/openssl_funcs.h
@@ -184,6 +184,10 @@ DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha256, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha384, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_224, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_256, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_384, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_512, (void), ()) \
 DEFINEFUNC_1_1(const GO_EVP_MD_PTR, EVP_md5_sha1, (void), ()) \
 DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_size, EVP_MD_size, (const GO_EVP_MD_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (GO_HMAC_CTX_PTR arg0), (arg0)) \

--- a/openssl/sha3/sha3.go
+++ b/openssl/sha3/sha3.go
@@ -1,0 +1,58 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sha3
+
+// Drop-in replacement for golang.org/x/crypto/sha3
+
+import (
+	"crypto"
+	"github.com/microsoft/go-crypto-openssl/openssl"
+)
+
+var (
+	New224 = openssl.NewSHA3_224
+	New256 = openssl.NewSHA3_256
+	New384 = openssl.NewSHA3_384
+	New512 = openssl.NewSHA3_512
+)
+
+func init() {
+	crypto.RegisterHash(crypto.SHA3_224, New224)
+	crypto.RegisterHash(crypto.SHA3_256, New256)
+	crypto.RegisterHash(crypto.SHA3_384, New384)
+	crypto.RegisterHash(crypto.SHA3_512, New512)
+}
+
+// Sum224 returns the SHA3-224 digest of the data.
+func Sum224(data []byte) (digest [28]byte) {
+	h := New224()
+	h.Write(data)
+	h.Sum(digest[:0])
+	return
+}
+
+// Sum256 returns the SHA3-256 digest of the data.
+func Sum256(data []byte) (digest [32]byte) {
+	h := New256()
+	h.Write(data)
+	h.Sum(digest[:0])
+	return
+}
+
+// Sum384 returns the SHA3-384 digest of the data.
+func Sum384(data []byte) (digest [48]byte) {
+	h := New384()
+	h.Write(data)
+	h.Sum(digest[:0])
+	return
+}
+
+// Sum512 returns the SHA3-512 digest of the data.
+func Sum512(data []byte) (digest [64]byte) {
+	h := New512()
+	h.Write(data)
+	h.Sum(digest[:0])
+	return
+}

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding"
 	"hash"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -25,10 +26,18 @@ func TestSha(t *testing.T) {
 		{"sha256", NewSHA256},
 		{"sha384", NewSHA384},
 		{"sha512", NewSHA512},
+		{"sha3_224", NewSHA3_224},
+		{"sha3_256", NewSHA3_256},
+		{"sha3_384", NewSHA3_384},
+		{"sha3_512", NewSHA3_512},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if strings.HasPrefix(tt.name, "sha3_") && vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+				t.Skip("crypto/sha3: only supported with openssl-1.1.1+")
+			}
 			h := tt.fn()
 			initSum := h.Sum(nil)
 			n, err := h.Write(msg)
@@ -45,7 +54,6 @@ func TestSha(t *testing.T) {
 			if bytes.Equal(sum, initSum) {
 				t.Error("Write didn't change internal hash state")
 			}
-
 			state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
 			if err != nil {
 				t.Errorf("could not marshal: %v", err)
@@ -57,7 +65,6 @@ func TestSha(t *testing.T) {
 			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
 				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
 			}
-
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
@@ -111,9 +118,28 @@ func TestSHA_OneShot(t *testing.T) {
 			b := SHA512(p)
 			return b[:]
 		}},
+		{"sha3_224", NewSHA3_224, func(p []byte) []byte {
+			b := SHA3_224(p)
+			return b[:]
+		}},
+		{"sha3_256", NewSHA3_256, func(p []byte) []byte {
+			b := SHA3_256(p)
+			return b[:]
+		}},
+		{"sha3_384", NewSHA3_384, func(p []byte) []byte {
+			b := SHA3_384(p)
+			return b[:]
+		}},
+		{"sha3_512", NewSHA3_512, func(p []byte) []byte {
+			b := SHA3_512(p)
+			return b[:]
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if strings.HasPrefix(tt.name, "sha3_") && vMajor == 1 && (vMinor == 0 || vFeature == 0) {
+				t.Skip("crypto/sha3: only supported with openssl-1.1.1+")
+			}
 			got := tt.oneShot(msg)
 			h := tt.want()
 			h.Write(msg)


### PR DESCRIPTION
This adds OpenSSL SHA-3 family of hashes in the openssl package.

Separately sha3 package is added as a drop-in replacement for golang.org/x/crypto/sha3 package.

Together with FIPS-compliant Go toolchain one can thus attempt building FIPS-compliant applications that use "crypto" package and also need FIPS-compliant SHA-3.

Marshaling is not cross-platform compatible (32/64 & be/le issues).

Fixes: https://github.com/microsoft/go-crypto-openssl/issues/57