### PR TITLE
Silence -Wpointer-sign warnings

### DIFF
--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -94,8 +94,8 @@ go_openssl_EVP_CIPHER_CTX_seal_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        const unsigned char *in, int in_len,
                                        const unsigned char *aad, int aad_len)
 {
-    if (in_len == 0) in = "";
-    if (aad_len == 0) aad = "";
+    if (in_len == 0) in = (const unsigned char *)"";
+    if (aad_len == 0) aad = (const unsigned char *)"";
 
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_ENCRYPT) != 1)
         return 0;
@@ -122,8 +122,8 @@ go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        const unsigned char *aad, int aad_len,
                                        const unsigned char *tag)
 {
-    if (in_len == 0) in = "";
-    if (aad_len == 0) aad = "";
+    if (in_len == 0) in = (const unsigned char *)"";
+    if (aad_len == 0) aad = (const unsigned char *)"";
 
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_DECRYPT) != 1)
         return 0;


### PR DESCRIPTION
Some C compilers assigning a string literal to a `const char *` variable elicits a warning.

Silence the warnings by casting the offending string literals to unsigned.

Ported from https://github.com/golang-fips/openssl/pull/98.
