### PR TITLE
Upgrade Go version used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.24.x]
         openssl-version-build: [1.0.2, 1.1.0, 1.1.1, 3.0.1]
         openssl-version-test: [1.0.2, 1.1.0, 1.1.1, 3.0.1]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Use latest available Go version, that is Go 1.24. This will unblock https://github.com/microsoft/go-crypto-openssl/pull/73.