### PR TITLE
Add CODEOWNERS for golang-compiler team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from golang-compiler team for changes in all files.
+
+* @microsoft/golang-compiler


### PR DESCRIPTION
Require review from golang-compiler team for all changes.