### PR TITLE
Drop hardcoded 3, 4 major version literals in switch statements

### DIFF
--- a/cmd/versionguardcheck/main.go
+++ b/cmd/versionguardcheck/main.go
@@ -5,8 +5,8 @@
 // "version checks must be justified" rule.
 //
 // It walks the OpenSSL backend's package ASTs and flags any call to
-// minor(), patch(), versionAtOrAbove(), or checkMajorVersion() that appears
-// inside the OpenSSL 3+ branch of a `switch major()` statement, unless the
+// minor(), patch(), or versionAtOrAbove() that appears inside the OpenSSL
+// 3+ branch of a `switch major()` statement, unless the
 // call is annotated with a marker comment of the form:
 //
 //	//versionguardcheck:ignore <reason>
@@ -49,10 +49,9 @@ const markerPrefix = "//versionguardcheck:ignore"
 // major() is intentionally excluded: the outer `switch major()` between
 // the 1.x and 3+ branches is the top-level dispatch and is exempt.
 var gatedFns = map[string]bool{
-	"minor":             true,
-	"patch":             true,
-	"versionAtOrAbove":  true,
-	"checkMajorVersion": true,
+	"minor":            true,
+	"patch":            true,
+	"versionAtOrAbove": true,
 }
 
 func main() {

--- a/cmd/versionguardcheck/testdata/badversion/badversion.go
+++ b/cmd/versionguardcheck/testdata/badversion/badversion.go
@@ -13,7 +13,6 @@ func major() int                        { return 3 }
 func minor() int                        { return 0 }
 func patch() int                        { return 0 }
 func versionAtOrAbove(a, b, c int) bool { return true }
-func checkMajorVersion(expected ...int) {}
 
 func threePlusBranch() {
 	switch major() {
@@ -22,8 +21,6 @@ func threePlusBranch() {
 		_ = minor()
 		// want: versionAtOrAbove
 		_ = versionAtOrAbove(3, 2, 0)
-		// want: checkMajorVersion
-		checkMajorVersion(3, 4)
 	}
 }
 

--- a/cmd/versionguardcheck/testdata/okversion/okversion.go
+++ b/cmd/versionguardcheck/testdata/okversion/okversion.go
@@ -11,7 +11,6 @@ func major() int                        { return 3 }
 func minor() int                        { return 0 }
 func patch() int                        { return 0 }
 func versionAtOrAbove(a, b, c int) bool { return true }
-func checkMajorVersion(expected ...int) {}
 
 func oneBranchOnly() {
 	switch major() {
@@ -20,7 +19,6 @@ func oneBranchOnly() {
 		_ = minor()
 		_ = patch()
 		_ = versionAtOrAbove(1, 1, 1)
-		checkMajorVersion(1)
 	}
 }
 

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -84,8 +84,7 @@ func loadCipher(k cipherKind, mode cipherMode) (cipher ossl.EVP_CIPHER_PTR) {
 	}
 	defer func() {
 		if cipher != nil {
-			switch major() {
-			case 3, 4:
+			if major() != 1 {
 				// On OpenSSL 3, directly operating on a EVP_CIPHER object
 				// not created by EVP_CIPHER has negative performance
 				// implications, as cipher operations will have

--- a/openssl/dsa.go
+++ b/openssl/dsa.go
@@ -93,7 +93,7 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_pqg(dsa, &p, &q, &g)
-	case 3, 4:
+	default:
 		defer func() {
 			ossl.BN_free(p)
 			ossl.BN_free(q)
@@ -108,8 +108,6 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G.ptr(), &g); err != nil {
 			return DSAParameters{}, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	return DSAParameters{
@@ -159,7 +157,7 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_key(dsa, &by, &bx)
-	case 3, 4:
+	default:
 		defer func() {
 			ossl.BN_clear_free(bx)
 			ossl.BN_free(by)
@@ -170,8 +168,6 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bx); err != nil {
 			return nil, nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return bnToBig(bx), bnToBig(by), nil
 }
@@ -190,16 +186,12 @@ func newDSA(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
 	switch major() {
 	case 1:
 		return newDSA1(params, x, y)
-	case 3, 4:
-		return newDSA3(params, x, y)
 	default:
-		panic(errUnsupportedVersion())
+		return newDSA3(params, x, y)
 	}
 }
 
 func newDSA1(params DSAParameters, x, y BigInt) (pkey ossl.EVP_PKEY_PTR, err error) {
-	checkMajorVersion(1)
-
 	dsa, err := ossl.DSA_new()
 	if err != nil {
 		return nil, err
@@ -245,8 +237,6 @@ func newDSA1(params DSAParameters, x, y BigInt) (pkey ossl.EVP_PKEY_PTR, err err
 }
 
 func newDSA3(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	bld := newParamBuilder()
 	defer bld.finalize()
 

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -107,7 +107,7 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			if bytes, err = encodeEcPoint(group, pt); err != nil {
 				return nil, err
 			}
-		case 3, 4:
+		default:
 			pkey = k._pkey
 			if _, err := ossl.EVP_PKEY_up_ref(pkey); err != nil {
 				return nil, err
@@ -119,8 +119,6 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			}
 			bytes = goBytes(unsafe.Pointer(cbytes), n)
 			cryptoFree(unsafe.Pointer(cbytes))
-		default:
-			panic(errUnsupportedVersion())
 		}
 	}
 	pub := &PublicKeyECDH{pkey, bytes}
@@ -141,16 +139,12 @@ func newECDHPkey(curve string, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR,
 	switch major() {
 	case 1:
 		return newECDHPkey1(nid, bytes, isPrivate)
-	case 3, 4:
-		return newECDHPkey3(nid, bytes, isPrivate)
 	default:
-		panic(errUnsupportedVersion())
+		return newECDHPkey3(nid, bytes, isPrivate)
 	}
 }
 
 func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey ossl.EVP_PKEY_PTR, err error) {
-	checkMajorVersion(1)
-
 	key, err := ossl.EC_KEY_new_by_curve_name(nid)
 	if err != nil {
 		return nil, err
@@ -203,8 +197,6 @@ func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey ossl.EVP_PKEY_P
 }
 
 func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	bld := newParamBuilder()
 	defer bld.finalize()
 	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
@@ -313,13 +305,11 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 			if priv == nil {
 				return nil, nil, fail("missing ECDH private key")
 			}
-		case 3, 4:
+		default:
 			if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &priv); err != nil {
 				return nil, nil, err
 			}
 			defer ossl.BN_clear_free(priv)
-		default:
-			panic(errUnsupportedVersion())
 		}
 		// We should not leak bit length of the secret scalar in the key.
 		// For this reason, we use BN_bn2binpad instead of BN_bn2bin with fixed length.

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -92,7 +92,7 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 		}
 		// Get Z. We don't need to free it, get0 does not increase the reference count.
 		bd = ossl.EC_KEY_get0_private_key(key)
-	case 3, 4:
+	default:
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X.ptr(), &bx); err != nil {
 			return nil, nil, nil, err
 		}
@@ -103,8 +103,6 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 			return nil, nil, nil, err
 		}
 		defer ossl.BN_clear_free(bd)
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	// Get D.
@@ -150,16 +148,12 @@ func newECDSAKey(curve string, x, y, d BigInt) (ossl.EVP_PKEY_PTR, error) {
 	switch major() {
 	case 1:
 		return newECDSAKey1(nid, bx, by, bd)
-	case 3, 4:
-		return newECDSAKey3(nid, bx, by, bd)
 	default:
-		panic(errUnsupportedVersion())
+		return newECDSAKey3(nid, bx, by, bd)
 	}
 }
 
 func newECDSAKey1(nid int32, bx, by, bd ossl.BIGNUM_PTR) (pkey ossl.EVP_PKEY_PTR, err error) {
-	checkMajorVersion(1)
-
 	key, err := ossl.EC_KEY_new_by_curve_name(nid)
 	if err != nil {
 		return nil, err
@@ -182,8 +176,6 @@ func newECDSAKey1(nid int32, bx, by, bd ossl.BIGNUM_PTR) (pkey ossl.EVP_PKEY_PTR
 }
 
 func newECDSAKey3(nid int32, bx, by, bd ossl.BIGNUM_PTR) (ossl.EVP_PKEY_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	// Create the encoded public key public key from bx and by.
 	pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group ossl.EC_GROUP_PTR) (ossl.EC_POINT_PTR, error) {
 		pt, err := ossl.EC_POINT_new(group)

--- a/openssl/ed25519.go
+++ b/openssl/ed25519.go
@@ -34,7 +34,7 @@ var supportsEd25519 = sync.OnceValue(func() bool {
 			ossl.EVP_PKEY_CTX_free(ctx)
 			return true
 		}
-	case 3, 4:
+	default:
 		sig, _ := ossl.EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)
 		if sig != nil {
 			ossl.EVP_SIGNATURE_free(sig)

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -183,16 +183,22 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	default:
 		if prov := ossl.EVP_MD_get0_provider(hash.md); prov != nil {
 			cname := ossl.OSSL_PROVIDER_get0_name(prov)
+			// Marshalability depends on knowing the EVP_MD_CTX internal
+			// layout for this major (see getOSSLDigetsContext). Untested
+			// majors loaded via GODEBUG=ms_opensslallowuntested=1 leave
+			// marshallable false so MarshalBinary/UnmarshalBinary return
+			// errMarshallUnsupported{} instead of touching unknown memory.
+			known := knownMajor()
 			switch goString(cname) {
 			case "default":
 				hash.provider = providerOSSLDefault
-				hash.marshallable = hash.magic != ""
+				hash.marshallable = known && hash.magic != ""
 			case "fips":
 				hash.provider = providerOSSLFIPS
-				hash.marshallable = hash.magic != ""
+				hash.marshallable = known && hash.magic != ""
 			case "symcryptprovider":
 				hash.provider = providerSymCrypt
-				hash.marshallable = hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
+				hash.marshallable = known && hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
 			}
 		}
 	}

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -159,8 +159,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	hash.ch = ch
 	hash.size = int(ossl.EVP_MD_get_size(hash.md))
 	hash.blockSize = int(ossl.EVP_MD_get_block_size(hash.md))
-	switch major() {
-	case 3, 4:
+	if major() != 1 {
 		// On OpenSSL 3, directly operating on a EVP_MD object
 		// not created by EVP_MD_fetch has negative performance
 		// implications, as digest operations will have
@@ -181,7 +180,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	switch major() {
 	case 1:
 		hash.provider = providerOSSLDefault
-	case 3, 4:
+	default:
 		if prov := ossl.EVP_MD_get0_provider(hash.md); prov != nil {
 			cname := ossl.OSSL_PROVIDER_get0_name(prov)
 			switch goString(cname) {
@@ -196,8 +195,6 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 				hash.marshallable = hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
 			}
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	cacheMD.Store(ch, &hash)
@@ -233,7 +230,7 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 		if _, err := ossl.EVP_PKEY_keygen(ctx, &pkey); err != nil {
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		switch id {
 		case ossl.EVP_PKEY_RSA:
@@ -260,8 +257,6 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 		if err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	return pkey, nil
@@ -386,10 +381,10 @@ func setOAEPPadding(ctx ossl.EVP_PKEY_CTX_PTR, h, mgfHash hash.Hash, label []byt
 		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 		var err error
 		switch major() {
-		case 3, 4:
-			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
-		default:
+		case 1:
 			_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
+		default:
+			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
 		}
 		if err != nil {
 			cryptoFree(unsafe.Pointer(clabel))

--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -16,11 +16,9 @@ func SupportsHKDF() bool {
 	switch major() {
 	case 1:
 		return true
-	case 3, 4:
+	default:
 		_, err := fetchHKDF3()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -29,18 +27,14 @@ func SupportsTLS13KDF() bool {
 	switch major() {
 	case 1:
 		return false
-	case 3, 4:
+	default:
 		// TLS13-KDF is available in OpenSSL 3.0.0 and later.
 		_, err := fetchTLS13_KDF()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
 func newHKDFCtx1(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info []byte) (ctx ossl.EVP_PKEY_CTX_PTR, err error) {
-	checkMajorVersion(1)
-
 	ctx, err = ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_HKDF, nil)
 	if err != nil {
 		return nil, err
@@ -129,7 +123,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 			return nil, err
 		}
 		return out[:keylen], nil
-	case 3, 4:
+	default:
 		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXTRACT_ONLY, secret, salt, nil, nil)
 		if err != nil {
 			return nil, err
@@ -144,8 +138,6 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 			return nil, err
 		}
 		return out, nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -178,7 +170,7 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int)
 		if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 		if err != nil {
 			return nil, err
@@ -193,8 +185,6 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int)
 		if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return out, nil
 }
@@ -228,8 +218,6 @@ func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, 
 // It is safe to call this function concurrently.
 // The returned EVP_KDF_PTR shouldn't be freed.
 var fetchTLS13_KDF = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS13_KDF.ptr(), nil)
 	if err != nil {
 		return nil, err
@@ -239,8 +227,6 @@ var fetchTLS13_KDF = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
 
 // newTLS13KDFExpandCtx3 fetches the "TLS13-KDF" for TLS 1.3 handshakes.
 func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey []byte) (_ ossl.EVP_KDF_CTX_PTR, err error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := fetchTLS13_KDF()
 	if err != nil {
 		return nil, err
@@ -281,8 +267,6 @@ func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey [
 // It is safe to call this function concurrently.
 // The returned EVP_KDF_PTR shouldn't be freed.
 var fetchHKDF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_HKDF.ptr(), nil)
 	if err != nil {
 		return nil, err
@@ -292,8 +276,6 @@ var fetchHKDF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
 
 // newHKDFCtx3 implements HKDF for OpenSSL 3 using the EVP_KDF API.
 func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info []byte) (_ ossl.EVP_KDF_CTX_PTR, err error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := fetchHKDF3()
 	if err != nil {
 		return nil, err

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -44,14 +44,12 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 			return nil
 		}
 		hmac.ctx1 = ctx
-	case 3, 4:
+	default:
 		ctx := newHMAC3(key, md)
 		if ctx.ctx == nil {
 			return nil
 		}
 		hmac.ctx3 = ctx
-	default:
-		panic(errUnsupportedVersion())
 	}
 	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 	return hmac
@@ -169,12 +167,10 @@ func (h *opensslHMAC) Reset() {
 		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, nil, nil); err != nil {
 			panic(err)
 		}
-	case 3, 4:
+	default:
 		if _, err := ossl.EVP_MAC_init(h.ctx3.ctx, h.ctx3.key, nil); err != nil {
 			panic(err)
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
@@ -194,10 +190,8 @@ func (h *opensslHMAC) Write(p []byte) (int, error) {
 		switch major() {
 		case 1:
 			ossl.HMAC_Update(h.ctx1.ctx, p)
-		case 3, 4:
-			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 		default:
-			panic(errUnsupportedVersion())
+			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 		}
 	}
 	runtime.KeepAlive(h)
@@ -228,15 +222,13 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 			panic(err)
 		}
 		ossl.HMAC_Final(ctx2, h.sum[:h.size], nil)
-	case 3, 4:
+	default:
 		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 		if err != nil {
 			panic(err)
 		}
 		defer ossl.EVP_MAC_CTX_free(ctx2)
 		ossl.EVP_MAC_final(ctx2, h.sum[:h.size], nil)
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return append(in, h.sum[:h.size]...)
 }
@@ -260,7 +252,7 @@ func (h *opensslHMAC) Clone() (HashCloner, error) {
 		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 		return cl, nil
 
-	case 3, 4:
+	default:
 		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 		if err != nil {
 			panic(err)
@@ -273,8 +265,5 @@ func (h *opensslHMAC) Clone() (HashCloner, error) {
 		}
 		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 		return cl, nil
-
-	default:
-		panic(errUnsupportedVersion())
 	}
 }

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -41,6 +41,15 @@ func patch() int {
 	return osslsetup.VersionPatch()
 }
 
+// knownMajor reports whether the loaded OpenSSL major is one this
+// backend has been tested against. Untested majors are only reachable
+// behind GODEBUG=ms_opensslallowuntested=1; code paths that rely on
+// version-specific layouts (e.g. EVP_MD_CTX internals) must guard on
+// this so they degrade safely instead of touching unknown memory.
+func knownMajor() bool {
+	return osslsetup.IsTestedMajor(major())
+}
+
 func utoa(n int) string {
 	return strconv.FormatUint(uint64(n), 10)
 }

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -49,16 +49,6 @@ func errUnsupportedVersion() error {
 	return errors.New("openssl: unsupported OpenSSL version: " + utoa(major()) + "." + utoa(minor()) + "." + utoa(patch()) + " (minimum supported version is 1.1.1)")
 }
 
-// checkMajorVersion panics if the current major version is not one of the expected versions.
-func checkMajorVersion(expected ...int) {
-	for _, v := range expected {
-		if major() == v {
-			return
-		}
-	}
-	panic("openssl: incorrect major version (" + strconv.Itoa(major()) + ")")
-}
-
 type fail string
 
 func (e fail) Error() string { return "openssl: " + string(e) + " failed" }

--- a/openssl/pbkdf2.go
+++ b/openssl/pbkdf2.go
@@ -16,11 +16,9 @@ func SupportsPBKDF2() bool {
 	switch major() {
 	case 1:
 		return true
-	case 3, 4:
+	default:
 		_, err := fetchPBKDF2()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -28,8 +26,6 @@ func SupportsPBKDF2() bool {
 // It is safe to call this function concurrently.
 // The returned EVP_KDF_PTR shouldn't be freed.
 var fetchPBKDF2 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_PBKDF2.ptr(), nil)
 	if err != nil {
 		return nil, err

--- a/openssl/provideropenssl.go
+++ b/openssl/provideropenssl.go
@@ -195,7 +195,13 @@ func getOSSLDigetsContext(ctx ossl.EVP_MD_CTX_PTR) unsafe.Pointer {
 		}
 		return (*mdCtx)(unsafe.Pointer(ctx)).algctx
 	default:
-		panic(errUnsupportedVersion())
+		// Unknown OpenSSL major: the EVP_MD_CTX internal layout is not known,
+		// so the running hash state cannot be safely extracted. osslsetup
+		// rejects untested majors at startup; this path is only reachable
+		// under GODEBUG=ms_opensslallowuntested=1. Callers surface a nil
+		// return as errHashStateInvalid, marking the hash effectively not
+		// marshalable on this version.
+		return nil
 	}
 }
 

--- a/openssl/provideropenssl.go
+++ b/openssl/provideropenssl.go
@@ -195,12 +195,13 @@ func getOSSLDigetsContext(ctx ossl.EVP_MD_CTX_PTR) unsafe.Pointer {
 		}
 		return (*mdCtx)(unsafe.Pointer(ctx)).algctx
 	default:
-		// Unknown OpenSSL major: the EVP_MD_CTX internal layout is not known,
-		// so the running hash state cannot be safely extracted. osslsetup
-		// rejects untested majors at startup; this path is only reachable
-		// under GODEBUG=ms_opensslallowuntested=1. Callers surface a nil
-		// return as errHashStateInvalid, marking the hash effectively not
-		// marshalable on this version.
+		// Unknown OpenSSL major: the EVP_MD_CTX internal layout is not
+		// known, so the running hash state cannot be safely extracted.
+		// loadHash marks hashes as not marshallable on untested majors
+		// (see evp.go), so MarshalBinary/UnmarshalBinary short-circuit
+		// with errMarshallUnsupported{} before calling this. The nil
+		// return is defense in depth against any future caller that
+		// bypasses that gate.
 		return nil
 	}
 }

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -38,7 +38,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		N, E, D = bnToBig(n), bnToBig(e), bnToBig(d)
 		P, Q = bnToBig(p), bnToBig(q)
 		Dp, Dq, Qinv = bnToBig(dmp1), bnToBig(dmq1), bnToBig(iqmp)
-	case 3, 4:
+	default:
 		tmp, err := ossl.BN_new()
 		if err != nil {
 			return bad(err)
@@ -67,8 +67,6 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 			setBigInt(&Qinv, _OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 			return bad(err)
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return
 }
@@ -106,13 +104,11 @@ func NewPublicKeyRSA(n, e BigInt) (*PublicKeyRSA, error) {
 			ossl.EVP_PKEY_free(pkey)
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		if pkey, err = newRSAKey3(false, n, e, nil, nil, nil, nil, nil, nil); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	k := &PublicKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
@@ -185,13 +181,11 @@ func NewPrivateKeyRSA(n, e, d, p, q, dp, dq, qinv BigInt) (*PrivateKeyRSA, error
 			ossl.EVP_PKEY_free(pkey)
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		if pkey, err = newRSAKey3(true, n, e, d, p, q, dp, dq, qinv); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	k := &PrivateKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)

--- a/openssl/tls1prf.go
+++ b/openssl/tls1prf.go
@@ -17,11 +17,9 @@ func SupportsTLS1PRF() bool {
 	switch major() {
 	case 1:
 		return minor() >= 1
-	case 3, 4:
+	default:
 		_, err := fetchTLS1PRF3()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -51,17 +49,13 @@ func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
 	switch major() {
 	case 1:
 		return tls1PRF1(result, secret, label, seed, md)
-	case 3, 4:
-		return tls1PRF3(result, secret, label, seed, md)
 	default:
-		return errUnsupportedVersion()
+		return tls1PRF3(result, secret, label, seed, md)
 	}
 }
 
 // tls1PRF1 implements TLS1PRF for OpenSSL 1 using the EVP_PKEY API.
 func tls1PRF1(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
-	checkMajorVersion(1)
-
 	ctx, err := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_TLS1_PRF, nil)
 	if err != nil {
 		return err
@@ -115,8 +109,6 @@ func tls1PRF1(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
 // It is safe to call this function concurrently.
 // The returned EVP_KDF_PTR shouldn't be freed.
 var fetchTLS1PRF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
-	checkMajorVersion(3, 4)
-
 	kdf, err := ossl.EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS1_PRF.ptr(), nil)
 	if err != nil {
 		return nil, err
@@ -126,8 +118,6 @@ var fetchTLS1PRF3 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
 
 // tls1PRF3 implements TLS1PRF for OpenSSL 3 using the EVP_KDF API.
 func tls1PRF3(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
-	checkMajorVersion(3, 4)
-
 	kdf, err := fetchTLS1PRF3()
 	if err != nil {
 		return err

--- a/osslsetup/osslsetup.go
+++ b/osslsetup/osslsetup.go
@@ -23,6 +23,20 @@ var (
 // [openLibrary].
 var testedMajors = [...]int{1, 3, 4}
 
+// IsTestedMajor reports whether m is one of the OpenSSL major versions
+// this backend has been tested against (see [testedMajors]). Callers
+// that depend on version-specific layouts or behaviors should gate on
+// this so they degrade safely on untested majors loaded via
+// GODEBUG=ms_opensslallowuntested=1.
+func IsTestedMajor(m int) bool {
+	for _, v := range testedMajors {
+		if v == m {
+			return true
+		}
+	}
+	return false
+}
+
 // allowUntestedMajor reports whether the user has set
 // GODEBUG=ms_opensslallowuntested=1. The "ms_" prefix marks this as a
 // Microsoft-defined GODEBUG so it will not collide with upstream Go.


### PR DESCRIPTION
Need to clean up leftover switch statements that hardcoded ossl 3 and 4 to fully support forward compatibility.

Convert:
switch major() {
case 1: ... legacy ...
case 3, 4: ... modern ...
default: panic(errUnsupportedVersion())
}

to:
switch major() {
case 1: ... legacy ...
default: ... modern ...
}

No behavior change for the currently tested majors. Future OpenSSL 5+ will exercise the 3+ code paths automatically once added to testedMajors in osslsetup/init.go.