### PR TITLE
Add path classifiers for CodeQL configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: autobuild
+          config-file: ./CodeQL.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,4 @@
+path_classifiers:
+  tests:
+    - "internal/cryptotest/*.go"
+    - "cmd/gentestvectors/main.go"


### PR DESCRIPTION
Adds the same path classifiers that we have in the darwin backend