### PR TITLE
mkcgo: restore 1-arg slice attribute support

### DIFF
--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -325,10 +325,13 @@ var attributes = [...]attribute{
 		name:        "slice",
 		description: "The parameter corresponds to a Go slice.",
 		handle: func(opts *Attrs, s ...string) error {
-			if len(s) != 2 {
-				return errors.New("requires 2 arguments")
+			if len(s) == 0 || len(s) > 2 {
+				return errors.New("requires 1 or 2 arguments")
 			}
-			slice := Slice{Ptr: s[0], Len: s[1]}
+			slice := Slice{Ptr: s[0]}
+			if len(s) == 2 {
+				slice.Len = s[1]
+			}
 			opts.Slice = append(opts.Slice, slice)
 			return nil
 		},

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -379,12 +379,12 @@ void F1(void) __attribute__((framework("t1")));
 			content: `
 void F1(void * p, int l) __attribute__((slice));
 `,
-			want: `can't extract function attributes: error parsing attribute slice: requires 2 arguments`,
+			want: `can't extract function attributes: error parsing attribute slice: requires 1 or 2 arguments`,
 		}, {
 			content: `
 void F1(void * p, int l, int m) __attribute__((slice("p", "l", "m")));
 `,
-			want: `can't extract function attributes: error parsing attribute slice: requires 2 arguments`,
+			want: `can't extract function attributes: error parsing attribute slice: requires 1 or 2 arguments`,
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
The slice attribute handler was changed to require exactly 2 arguments in 920ecfb, but the `Attrs.String()` serializer still handles `Len==""` correctly. This broke downstream consumers (go-crypto-darwin) that use `slice(ptr)` for fixed-size buffers with no explicit length parameter (e.g. IV, tag, key buffers with known sizes).

Restore support for 1 or 2 arguments to match the serializer behavior.

Fixes parsing errors like:
```
error parsing attribute slice: requires 2 arguments
```
for declarations such as:
```c
CCCryptorStatus CCCryptorCreate(..., const void *iv, ...) __attribute__((slice(iv)));
```