### PR TITLE
fakecgo: remove load_g references

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,8 +215,13 @@ jobs:
                 ln -sf /usr/lib/s390x-linux-gnu/ld64.so.1 /lib64/ld64.so.1
                 ;;
             esac
-            go test -shuffle=on -count 3 -v ./...
-            go test -bench=./... -run='^$' -benchtime=1x ./...
+            # TODO: Remove -checklinkname=0 once go tip no longer requires it.
+            LDFLAGS=''
+            if [ '${{ matrix.go-version }}' = 'tip' ]; then
+              LDFLAGS='-ldflags=-checklinkname=0'
+            fi
+            go test -shuffle=on -count 3 \$LDFLAGS -v ./...
+            go test -bench=./... -run='^$' -benchtime=1x \$LDFLAGS ./...
           "
 
   freebsd:

--- a/internal/fakecgo/asm_arm.s
+++ b/internal/fakecgo/asm_arm.s
@@ -32,8 +32,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	MOVD F14, (13*4+8*7)(R13)
 	MOVD F15, (13*4+8*8)(R13)
 
-	BL runtime·load_g(SB)
-
 	// We set up the arguments to cgocallback when saving registers above.
 	BL runtime·cgocallback(SB)
 

--- a/internal/fakecgo/asm_arm64.s
+++ b/internal/fakecgo/asm_arm64.s
@@ -25,7 +25,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	STP (R29, R30), (8*22)(RSP)
 
 	// Initialize Go ABI environment
-	BL runtime·load_g(SB)
 	BL runtime·cgocallback(SB)
 
 	RESTORE_R19_TO_R28(8*4)

--- a/internal/fakecgo/asm_loong64.s
+++ b/internal/fakecgo/asm_loong64.s
@@ -27,8 +27,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	MOVV R1, (22*8)(R3)
 
 	// Initialize Go ABI environment
-	JAL runtime·load_g(SB)
-
 	JAL runtime·cgocallback(SB)
 
 	RESTORE_R22_TO_R31((4*8))

--- a/internal/fakecgo/asm_ppc64le.s
+++ b/internal/fakecgo/asm_ppc64le.s
@@ -50,9 +50,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	// Initialize R0 to 0 as expected by Go
 	MOVD $0, R0
 
-	// Load the current g.
-	BL runtime·load_g(SB)
-
 	// Set up arguments for cgocallback
 	MOVD R3, FIXED_FRAME+0(R1) // fn unsafe.Pointer
 	MOVD R4, FIXED_FRAME+8(R1) // a unsafe.Pointer

--- a/internal/fakecgo/asm_riscv64.s
+++ b/internal/fakecgo/asm_riscv64.s
@@ -25,7 +25,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	SAVE_FPR((8*17))
 
 	// Initialize Go ABI environment
-	CALL runtime·load_g(SB)
 	CALL runtime·cgocallback(SB)
 
 	RESTORE_GPR((8*4))

--- a/internal/fakecgo/asm_s390x.s
+++ b/internal/fakecgo/asm_s390x.s
@@ -27,9 +27,6 @@ TEXT crosscall2(SB), NOSPLIT|NOFRAME, $0
 	FMOVD F14, 80(R15)
 	FMOVD F15, 88(R15)
 
-	// Initialize Go ABI environment.
-	BL runtime·load_g(SB)
-
 	MOVD R2, 8(R15)  // fn unsafe.Pointer
 	MOVD R3, 16(R15) // a unsafe.Pointer
 

--- a/internal/fakecgo/fakecgo.lock
+++ b/internal/fakecgo/fakecgo.lock
@@ -1,3 +1,3 @@
 {
-  "commit_hash": "5110604b3385278be6887d0feead513a1bfe7a82"
+  "commit_hash": "1512f327e9958354283654ee4497800e33a7b838"
 }

--- a/internal/fakecgo/trampolines_ppc64le.s
+++ b/internal/fakecgo/trampolines_ppc64le.s
@@ -47,15 +47,19 @@ TEXT x_cgo_bindm_trampoline(SB), NOSPLIT, $0-0
 
 // func setg_trampoline(setg uintptr, g uintptr)
 TEXT ·setg_trampoline(SB), NOSPLIT, $16-16
-	MOVD R31, 8(R1) // save R31 (load_g clobbers it)
+	MOVD R31, 8(R1) // save R31
 
 	MOVD setg+0(FP), R12
 	MOVD newg+8(FP), R3
 
+	MOVD R3, 16(R1) // save newg before call
+
 	MOVD R12, CTR
 	CALL CTR
 
-	CALL runtime·load_g(SB)
+	// Assign g directly instead of calling runtime·load_g
+	// setg_gcc has already stored newg into TLS; put it in the g register too.
+	MOVD 16(R1), g
 
 	MOVD 8(R1), R31
 	XOR  R0, R0, R0

--- a/internal/fakecgo/trampolines_s390x.s
+++ b/internal/fakecgo/trampolines_s390x.s
@@ -85,9 +85,13 @@ TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
 	SUB  $160, R15
 	MOVD R3, 0(R15)
 	MOVD R0, 112(R15)
+	MOVD R2, 120(R15)  // save newg before call
 
-	BL R1                 // call setg_gcc
-	BL runtime·load_g(SB)
+	BL R1 // call setg_gcc
+
+	// Assign g directly instead of calling runtime·load_g
+	// setg_gcc has already stored newg into TLS; put it in the g register too.
+	MOVD 120(R15), g
 
 	MOVD 112(R15), R14
 	ADD  $160, R15


### PR DESCRIPTION
Go 1.27 (tip) introduces stricter checklinkname enforcement for assembly symbols via [golang/go@aee6009](https://github.com/golang/go/commit/aee6009ba5e1d71948b03ac0458fbc99e3a14ace). This causes linker errors when building with CGO_ENABLED=0 on all architectures, because the fakecgo assembly files reference runtime.load_g and runtime.cgocallback, which are now //go:linknamestd (std-only).