### PR TITLE
Support OpenSSL 3.5 built-in FIPS provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
         go test -v -count 0 ./openssl | grep -q "FIPS enabled: true"
-      if: ${{ matrix.openssl-version == '3.0.1' }}
+      if: ${{ matrix.openssl-version == '3.0.1' || matrix.openssl-version == '3.5.6' }}
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
     - name: Run Test

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -280,6 +280,7 @@ int EVP_CIPHER_CTX_set_key_length(_EVP_CIPHER_CTX_PTR x, int keylen);
 void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
+int EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, const unsigned char *key, const unsigned char *iv, int enc, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback,slice("out","outl"),slice("in","inl")));
 int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
 int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback,slice("out","outl"),slice("in","inl")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -67,6 +67,7 @@ _EVP_CIPHER_PTR (*_g_EVP_CIPHER_fetch)(_OSSL_LIB_CTX_PTR, const char*, const cha
 const char* (*_g_EVP_CIPHER_get0_name)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CIPHER_get_block_size)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CipherInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int);
+int (*_g_EVP_CipherInit_ex2)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR);
 int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
 int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
@@ -502,6 +503,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_CIPHER_fetch)
 	__mkcgo__dlsym(EVP_CIPHER_get0_name)
 	__mkcgo__dlsym(EVP_CIPHER_get_block_size)
+	__mkcgo__dlsym(EVP_CipherInit_ex2)
 	__mkcgo__dlsym(EVP_KDF_CTX_free)
 	__mkcgo__dlsym(EVP_KDF_CTX_get_kdf_size)
 	__mkcgo__dlsym(EVP_KDF_CTX_new)
@@ -577,6 +579,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_CIPHER_fetch = NULL;
 	_g_EVP_CIPHER_get0_name = NULL;
 	_g_EVP_CIPHER_get_block_size = NULL;
+	_g_EVP_CipherInit_ex2 = NULL;
 	_g_EVP_KDF_CTX_free = NULL;
 	_g_EVP_KDF_CTX_get_kdf_size = NULL;
 	_g_EVP_KDF_CTX_new = NULL;
@@ -1059,6 +1062,12 @@ int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR _arg0) {
 
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, int _arg5, uintptr_t *_err_state) {
 	int _ret = _g_EVP_CipherInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, const unsigned char* _arg2, const unsigned char* _arg3, int _arg4, const _OSSL_PARAM_PTR _arg5, uintptr_t *_err_state) {
+	int _ret = _g_EVP_CipherInit_ex2(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -184,6 +184,7 @@ _EVP_CIPHER_PTR _mkcgo_EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR, const char*, const ch
 const char* _mkcgo_EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int, uintptr_t *);
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR, uintptr_t *);
 int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, uintptr_t *);
 int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, uintptr_t *);
 int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -446,6 +446,12 @@ func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGIN
 	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", uintptr(_err))
 }
 
+func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_CipherInit_ex2(ctx, __type, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc), params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex2", uintptr(_err))
+}
+
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
 	if outl != nil && int(*outl) > len(out) {
 		panic("EVP_CipherUpdate: *outl exceeds len(out)")

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -431,6 +431,14 @@ func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGIN
 	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", _err)
 }
 
+var _mkcgo_EVP_CipherInit_ex2 uintptr
+
+func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex2, uintptr(ctx), uintptr(__type), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(key))), uintptr(mkcgoEscapePtrOssl(unsafe.Pointer(iv))), uintptr(enc), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_CipherInit_ex2", _err)
+}
+
 var _mkcgo_EVP_CipherUpdate uintptr
 
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out []byte, outl *int32, in []byte) (int32, error) {
@@ -2181,6 +2189,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_CIPHER_fetch = dlsym(handle, "EVP_CIPHER_fetch\x00", false)
 	_mkcgo_EVP_CIPHER_get0_name = dlsym(handle, "EVP_CIPHER_get0_name\x00", false)
 	_mkcgo_EVP_CIPHER_get_block_size = dlsym(handle, "EVP_CIPHER_get_block_size\x00", false)
+	_mkcgo_EVP_CipherInit_ex2 = dlsym(handle, "EVP_CipherInit_ex2\x00", false)
 	_mkcgo_EVP_KDF_CTX_free = dlsym(handle, "EVP_KDF_CTX_free\x00", false)
 	_mkcgo_EVP_KDF_CTX_get_kdf_size = dlsym(handle, "EVP_KDF_CTX_get_kdf_size\x00", false)
 	_mkcgo_EVP_KDF_CTX_new = dlsym(handle, "EVP_KDF_CTX_new\x00", false)
@@ -2256,6 +2265,7 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_CIPHER_fetch = 0
 	_mkcgo_EVP_CIPHER_get0_name = 0
 	_mkcgo_EVP_CIPHER_get_block_size = 0
+	_mkcgo_EVP_CipherInit_ex2 = 0
 	_mkcgo_EVP_KDF_CTX_free = 0
 	_mkcgo_EVP_KDF_CTX_get_kdf_size = 0
 	_mkcgo_EVP_KDF_CTX_new = 0

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -625,9 +625,6 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if err != nil {
 		return nil, err
 	}
-	if params != nil {
-		defer ossl.OSSL_PARAM_free(params)
-	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -661,15 +658,20 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	return ctx, nil
 }
 
+var cipherEncryptCheckParams = sync.OnceValues(func() (ossl.OSSL_PARAM_PTR, error) {
+	bld := newParamBuilder()
+	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
+	return bld.build()
+})
+
 func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
 	if encrypt != cipherOpEncrypt || major() == 1 {
 		return nil, nil
 	}
-	bld := newParamBuilder()
+	// The returned params are cached for the lifetime of the process and must not be freed by callers.
 	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
 	// This check is done at the Go crypto level.
-	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
-	return bld.build()
+	return cipherEncryptCheckParams()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -621,6 +621,13 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if cipher == nil {
 		panic("crypto/cipher: unsupported cipher: " + kind.String())
 	}
+	params, err := cipherInitParams(encrypt)
+	if err != nil {
+		return nil, err
+	}
+	if params != nil {
+		defer ossl.OSSL_PARAM_free(params)
+	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -643,10 +650,26 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 		cipher = nil
 	}
-	if _, err := ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
+	if params != nil {
+		_, err = ossl.EVP_CipherInit_ex2(ctx, cipher, base(key), base(iv), int32(encrypt), params)
+	} else {
+		_, err = ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt))
+	}
+	if err != nil {
 		return nil, err
 	}
 	return ctx, nil
+}
+
+func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
+	if encrypt != cipherOpEncrypt || major() == 1 {
+		return nil, nil
+	}
+	bld := newParamBuilder()
+	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
+	// This check is done at the Go crypto level.
+	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
+	return bld.build()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -101,8 +101,13 @@ const ( //checkheader:ignore
 	_OSSL_PKEY_PARAM_ML_DSA_SEED        cString = "seed\x00"
 
 	// Signature parameters
-	_OSSL_SIGNATURE_PARAM_CONTEXT_STRING cString = "context-string\x00"
-	_OSSL_SIGNATURE_PARAM_MU             cString = "mu\x00"
+	_OSSL_SIGNATURE_PARAM_DIGEST                     cString = "digest\x00"
+	_OSSL_SIGNATURE_PARAM_PAD_MODE                   cString = "pad-mode\x00"
+	_OSSL_SIGNATURE_PARAM_PSS_SALTLEN                cString = "saltlen\x00"
+	_OSSL_SIGNATURE_PARAM_CONTEXT_STRING             cString = "context-string\x00"
+	_OSSL_SIGNATURE_PARAM_MU                         cString = "mu\x00"
+	_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK cString = "rsa-pss-saltlen-check\x00"
+	_OSSL_PKEY_RSA_PAD_MODE_PSS                      cString = "pss\x00"
 
 	// MAC parameters
 	_OSSL_MAC_PARAM_DIGEST         cString = "digest\x00"

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -69,7 +69,8 @@ const ( //checkheader:ignore
 	_OSSL_KDF_PARAM_MODE     cString = "mode\x00"
 
 	// KDF FIPS parameters
-	_OSSL_KDF_PARAM_FIPS_KEY_CHECK cString = "key-check\x00"
+	_OSSL_KDF_PARAM_FIPS_KEY_CHECK        cString = "key-check\x00"
+	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
 
 	// TLS3-KDF parameters
 	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -320,19 +320,37 @@ func setPSSPadding(ctx ossl.EVP_PKEY_CTX_PTR, saltLen int32, ch crypto.Hash) err
 	if alg == nil {
 		return errors.New("crypto/rsa: unsupported hash function")
 	}
-	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-		return err
-	}
-	// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
-		return err
-	}
-	if saltLen != 0 {
-		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+	switch major() {
+	case 1:
+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
 			return err
 		}
+		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
+			return err
+		}
+		if saltLen != 0 {
+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		bld := newParamBuilder()
+		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
+		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
+		if saltLen != 0 {
+			bld.addInt32(_OSSL_SIGNATURE_PARAM_PSS_SALTLEN, saltLen)
+		}
+		bld.addInt32(_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK, 0)
+		params, err := bld.build()
+		if err != nil {
+			return err
+		}
+		defer ossl.OSSL_PARAM_free(params)
+		_, err = ossl.EVP_PKEY_CTX_set_params(ctx, params)
+		return err
 	}
-	return nil
 }
 
 func setPKCS1Padding(ctx ossl.EVP_PKEY_CTX_PTR, ch crypto.Hash) error {


### PR DESCRIPTION
The OpenSSL 3.5 built-in FIPS provider got a bit stricter. The FIPS-enforcement logic belongs to the Go crypto packages, not to the backend. Make OpenSSL less strict.

For https://github.com/microsoft/go/issues/2322