### PR TITLE
[ms-go1.25-support] Support OpenSSL 3.5 built-in FIPS provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         $ok
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        ASAN_OPTIONS: detect_leaks=0
   wintest:
     runs-on: windows-2022
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Set OpenSSL config and prove FIPS
       run: |
         sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-        go test -v -count 0 . | grep -q "FIPS enabled: true"
-      if: ${{ matrix.openssl-version == '3.0.1' }}
+        go test -v -count 0 ./openssl | grep -q "FIPS enabled: true"
+      if: ${{ matrix.openssl-version == '3.0.1' || matrix.openssl-version == '3.5.6' }}
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
     - name: Run Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,12 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [/usr/local/opt/openssl@3/lib/libcrypto.3.dylib]
-    runs-on: macos-13
+        host: [
+          # the non-intel macOS runners use ARM64
+          {os: macos-15-intel, openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib},
+          {os: macos-15, openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib}
+        ]
+    runs-on: ${{ matrix.host.os }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v5
@@ -86,7 +90,7 @@ jobs:
     - name: Run Test
       run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
   azurelinux:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/oss/go/microsoft/golang:1.23-azurelinux3.0

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -272,6 +272,7 @@ int EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR pkey, const char *key_name, _BIGNU
 int EVP_PKEY_up_ref(_EVP_PKEY_PTR key) __attribute__((tag("3")));
 int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int len) __attribute__((tag("3")));
+int EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -246,6 +246,7 @@ int EVP_CIPHER_CTX_set_key_length(_EVP_CIPHER_CTX_PTR x, int keylen);
 void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
+int EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, const unsigned char *key, const unsigned char *iv, int enc, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
 int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
 int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -62,6 +62,7 @@ _EVP_CIPHER_PTR (*_g_EVP_CIPHER_fetch)(_OSSL_LIB_CTX_PTR, const char*, const cha
 const char* (*_g_EVP_CIPHER_get0_name)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CIPHER_get_block_size)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CipherInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int);
+int (*_g_EVP_CipherInit_ex2)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR);
 int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
 int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
@@ -484,6 +485,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_CIPHER_fetch)
 	__mkcgo__dlsym(EVP_CIPHER_get0_name)
 	__mkcgo__dlsym(EVP_CIPHER_get_block_size)
+	__mkcgo__dlsym(EVP_CipherInit_ex2)
 	__mkcgo__dlsym(EVP_KDF_CTX_free)
 	__mkcgo__dlsym(EVP_KDF_CTX_get_kdf_size)
 	__mkcgo__dlsym(EVP_KDF_CTX_new)
@@ -552,6 +554,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_CIPHER_fetch = NULL;
 	_g_EVP_CIPHER_get0_name = NULL;
 	_g_EVP_CIPHER_get_block_size = NULL;
+	_g_EVP_CipherInit_ex2 = NULL;
 	_g_EVP_KDF_CTX_free = NULL;
 	_g_EVP_KDF_CTX_get_kdf_size = NULL;
 	_g_EVP_KDF_CTX_new = NULL;
@@ -996,6 +999,12 @@ int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR _arg0) {
 
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, int _arg5, mkcgo_err_state *_err_state) {
 	int _ret = _g_EVP_CipherInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, const unsigned char* _arg2, const unsigned char* _arg3, int _arg4, const _OSSL_PARAM_PTR _arg5, mkcgo_err_state *_err_state) {
+	int _ret = _g_EVP_CipherInit_ex2(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -122,6 +122,7 @@ int (*_g_EVP_PKEY_CTX_set1_hkdf_key)(_EVP_PKEY_CTX_PTR, const unsigned char*, in
 int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
 int (*_g_EVP_PKEY_CTX_set_hkdf_mode)(_EVP_PKEY_CTX_PTR, int);
+int (*_g_EVP_PKEY_CTX_set_params)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 _EVP_PKEY_PTR (*_g_EVP_PKEY_Q_keygen)(_OSSL_LIB_CTX_PTR, const char*, const char*, ...);
 int (*_g_EVP_PKEY_assign)(_EVP_PKEY_PTR, int, void*);
 int (*_g_EVP_PKEY_decrypt)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
@@ -519,6 +520,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_salt)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_md)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_mode)
+	__mkcgo__dlsym(EVP_PKEY_CTX_set_params)
 	__mkcgo__dlsym(EVP_PKEY_Q_keygen)
 	__mkcgo__dlsym(EVP_PKEY_fromdata)
 	__mkcgo__dlsym(EVP_PKEY_fromdata_init)
@@ -588,6 +590,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_PKEY_CTX_set1_hkdf_salt = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_md = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_mode = NULL;
+	_g_EVP_PKEY_CTX_set_params = NULL;
 	_g_EVP_PKEY_Q_keygen = NULL;
 	_g_EVP_PKEY_fromdata = NULL;
 	_g_EVP_PKEY_fromdata_init = NULL;
@@ -1337,6 +1340,12 @@ int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR _arg0, const _EVP_MD_PTR _
 
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
 	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
+	int _ret = _g_EVP_PKEY_CTX_set_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.go
+++ b/internal/ossl/zossl.go
@@ -406,6 +406,12 @@ func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGIN
 	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", _err)
 }
 
+func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.mkcgo_err_state
+	_ret := C._mkcgo_EVP_CipherInit_ex2(ctx, __type, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc), params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex2", _err)
+}
+
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 	var _err C.mkcgo_err_state
 	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))

--- a/internal/ossl/zossl.go
+++ b/internal/ossl/zossl.go
@@ -744,6 +744,12 @@ func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error
 	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", _err)
 }
 
+func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.mkcgo_err_state
+	_ret := C._mkcgo_EVP_PKEY_CTX_set_params(ctx, params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_params", _err)
+}
+
 func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
 	var _err C.mkcgo_err_state
 	_ret := C._mkcgo_EVP_PKEY_Q_keygen_EC(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), (*C.char)(unsafe.Pointer(arg1)), mkcgoNoEscape(&_err))

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -159,6 +159,7 @@ _EVP_CIPHER_PTR _mkcgo_EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR, const char*, const ch
 const char* _mkcgo_EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int, mkcgo_err_state *);
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR, mkcgo_err_state *);
 int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, mkcgo_err_state *);
 int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, mkcgo_err_state *);
 int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, mkcgo_err_state *);

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -219,6 +219,7 @@ int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR, const unsigned char*, i
 int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, mkcgo_err_state *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, mkcgo_err_state *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR, int, mkcgo_err_state *);
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, mkcgo_err_state *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR, const char*, const char*, const char*, mkcgo_err_state *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR, const char*, const char*, mkcgo_err_state *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR, const char*, const char*, size_t, mkcgo_err_state *);

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -614,9 +614,6 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if err != nil {
 		return nil, err
 	}
-	if params != nil {
-		defer ossl.OSSL_PARAM_free(params)
-	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -650,15 +647,23 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	return ctx, nil
 }
 
-func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
-	if encrypt != cipherOpEncrypt || major() == 1 {
-		return nil, nil
+var cipherEncryptCheckParams = sync.OnceValues(func() (ossl.OSSL_PARAM_PTR, error) {
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
-	bld := newParamBuilder()
-	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
-	// This check is done at the Go crypto level.
 	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
 	return bld.build()
+})
+
+func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
+	if encrypt != cipherOpEncrypt || vMajor == 1 {
+		return nil, nil
+	}
+	// The returned params are cached for the lifetime of the process and must not be freed by callers.
+	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
+	// This check is done at the Go crypto level.
+	return cipherEncryptCheckParams()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -610,6 +610,13 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if cipher == nil {
 		panic("crypto/cipher: unsupported cipher: " + kind.String())
 	}
+	params, err := cipherInitParams(encrypt)
+	if err != nil {
+		return nil, err
+	}
+	if params != nil {
+		defer ossl.OSSL_PARAM_free(params)
+	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -632,10 +639,26 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 		cipher = nil
 	}
-	if _, err := ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
+	if params != nil {
+		_, err = ossl.EVP_CipherInit_ex2(ctx, cipher, base(key), base(iv), int32(encrypt), params)
+	} else {
+		_, err = ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt))
+	}
+	if err != nil {
 		return nil, err
 	}
 	return ctx, nil
+}
+
+func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
+	if encrypt != cipherOpEncrypt || major() == 1 {
+		return nil, nil
+	}
+	bld := newParamBuilder()
+	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
+	// This check is done at the Go crypto level.
+	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
+	return bld.build()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -63,6 +63,9 @@ const ( //checkheader:ignore
 	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 
+	// Cipher parameters
+	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
+
 	// TLS3-KDF parameters
 	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"
 	_OSSL_KDF_PARAM_LABEL  cString = "label\x00"

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -91,6 +91,13 @@ const ( //checkheader:ignore
 	_OSSL_PKEY_PARAM_RSA_EXPONENT2    cString = "rsa-exponent2\x00"
 	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1 cString = "rsa-coefficient1\x00"
 
+	// Signature parameters
+	_OSSL_SIGNATURE_PARAM_DIGEST                     cString = "digest\x00"
+	_OSSL_SIGNATURE_PARAM_PAD_MODE                   cString = "pad-mode\x00"
+	_OSSL_SIGNATURE_PARAM_PSS_SALTLEN                cString = "saltlen\x00"
+	_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK cString = "rsa-pss-saltlen-check\x00"
+	_OSSL_PKEY_RSA_PAD_MODE_PSS                      cString = "pss\x00"
+
 	// MAC parameters
 	_OSSL_MAC_PARAM_DIGEST cString = "digest\x00"
 )

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -63,7 +63,8 @@ const ( //checkheader:ignore
 	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 
-	// Cipher parameters
+	// KDF FIPS parameters
+	_OSSL_KDF_PARAM_FIPS_KEY_CHECK        cString = "key-check\x00"
 	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
 
 	// TLS3-KDF parameters

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -337,15 +337,37 @@ func setupEVP(withKey withKeyFunc, padding int32,
 		if alg == nil {
 			return nil, errors.New("crypto/rsa: unsupported hash function")
 		}
-		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-			return nil, err
-		}
-		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-		if err := setPadding(); err != nil {
-			return nil, err
-		}
-		if saltLen != 0 {
-			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+		switch vMajor {
+		case 1:
+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
+				return nil, err
+			}
+			// setPadding must happen after setting EVP_PKEY_CTRL_MD.
+			if err := setPadding(); err != nil {
+				return nil, err
+			}
+			if saltLen != 0 {
+				if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			bld, err := newParamBuilder()
+			if err != nil {
+				return nil, err
+			}
+			bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
+			bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
+			if saltLen != 0 {
+				bld.addInt32(_OSSL_SIGNATURE_PARAM_PSS_SALTLEN, saltLen)
+			}
+			bld.addInt32(_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK, 0)
+			params, err := bld.build()
+			if err != nil {
+				return nil, err
+			}
+			defer ossl.OSSL_PARAM_free(params)
+			if _, err := ossl.EVP_PKEY_CTX_set_params(ctx, params); err != nil {
 				return nil, err
 			}
 		}

--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -390,6 +390,7 @@ func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, 
 	if err != nil {
 		return ctx, err
 	}
+	bld.addInt32(_OSSL_KDF_PARAM_FIPS_KEY_CHECK, 0)
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 	bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)

--- a/openssl/hkdf_test.go
+++ b/openssl/hkdf_test.go
@@ -354,6 +354,7 @@ func TestHKDFMultiRead(t *testing.T) {
 		hkdf, err := newHKDF(tt.hash, tt.master, tt.salt, tt.info)
 		if err != nil {
 			t.Errorf("test %d: error creating HKDF: %v.", i, err)
+			continue
 		}
 		out := make([]byte, len(tt.out))
 

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"hash"
 	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/microsoft/go-crypto-openssl/internal/ossl"
@@ -224,6 +225,40 @@ func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 	return evpEncrypt(pub.withKey, ossl.RSA_PKCS1_PADDING, nil, nil, nil, msg)
 }
+
+// SupportsRSAPKCS1v15Encryption returns true if RSA PKCS1 v1.5 padding is supported for encryption and decryption.
+var SupportsRSAPKCS1v15Encryption = sync.OnceValue(func() bool {
+	n, e, _, _, _, _, _, _, err := GenerateKeyRSA(2048)
+	if err != nil {
+		return false
+	}
+	pub, err := NewPublicKeyRSA(n, e)
+	if err != nil {
+		return false
+	}
+	supported := false
+	_ = pub.withKey(func(pkey ossl.EVP_PKEY_PTR) error {
+		ctx, err := ossl.EVP_PKEY_CTX_new(pkey, nil)
+		if err != nil {
+			return err
+		}
+		defer ossl.EVP_PKEY_CTX_free(ctx)
+		if _, err := ossl.EVP_PKEY_encrypt_init(ctx); err != nil {
+			return err
+		}
+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PADDING, nil); err != nil {
+			return err
+		}
+		in := []byte("test")
+		var outLen int
+		if _, err := ossl.EVP_PKEY_encrypt(ctx, nil, &outLen, base(in), len(in)); err != nil {
+			return err
+		}
+		supported = true
+		return nil
+	})
+	return supported
+})
 
 func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 	ret, err := evpDecrypt(priv.withKey, ossl.RSA_NO_PADDING, nil, nil, nil, ciphertext)

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/microsoft/go-crypto-openssl/openssl"
 	"github.com/microsoft/go-crypto-openssl/bbig"
+	"github.com/microsoft/go-crypto-openssl/openssl"
 )
 
 func TestRSAKeyGeneration(t *testing.T) {
@@ -42,6 +42,9 @@ func testRSAEncryptDecryptPKCS1(t *testing.T, priv *openssl.PrivateKeyRSA, pub *
 }
 
 func TestRSAEncryptDecryptPKCS1(t *testing.T) {
+	if !openssl.SupportsRSAPKCS1v15Encryption() {
+		t.Skip("RSA PKCS1 v1.5 encryption not supported")
+	}
 	for _, size := range []int{2048, 3072} {
 		size := size
 		t.Run(strconv.Itoa(size), func(t *testing.T) {
@@ -53,6 +56,9 @@ func TestRSAEncryptDecryptPKCS1(t *testing.T) {
 }
 
 func TestRSAEncryptDecryptPKCS1_MissingPrecomputedValues(t *testing.T) {
+	if !openssl.SupportsRSAPKCS1v15Encryption() {
+		t.Skip("RSA PKCS1 v1.5 encryption not supported")
+	}
 	n, e, d, p, q, dp, dq, qinv, err := openssl.GenerateKeyRSA(2048)
 	if err != nil {
 		t.Fatalf("GenerateKeyRSA: %v", err)
@@ -388,6 +394,9 @@ func fromBase36(base36 string) *big.Int {
 }
 
 func BenchmarkEncryptRSAPKCS1(b *testing.B) {
+	if !openssl.SupportsRSAPKCS1v15Encryption() {
+		b.Skip("RSA PKCS1 v1.5 encryption not supported")
+	}
 	b.StopTimer()
 	// Public key length should be at least of 2048 bits, else OpenSSL will report an error when running in FIPS mode.
 	n := fromBase36("14314132931241006650998084889274020608918049032671858325988396851334124245188214251956198731333464217832226406088020736932173064754214329009979944037640912127943488972644697423190955557435910767690712778463524983667852819010259499695177313115447116110358524558307947613422897787329221478860907963827160223559690523660574329011927531289655711860504630573766609239332569210831325633840174683944553667352219670930408593321661375473885147973879086994006440025257225431977751512374815915392249179976902953721486040787792801849818254465486633791826766873076617116727073077821584676715609985777563958286637185868165868520557")


### PR DESCRIPTION
Backport of #17 to ms-go1.25-support.

Validation:
- Focused DES/RSA tests via VS Code test runner: 32 passed
- go test ./...