### PR TITLE
[ms-go1.26-support] Support OpenSSL 3.5 built-in FIPS provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
         $ok
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        ASAN_OPTIONS: detect_leaks=0
 
   ossltest:
     strategy:
@@ -137,11 +138,6 @@ jobs:
         cgo: [1, 0]
         exclude:
           - architecture: s390x
-            cgo: 0
-        include:
-          # s390x CGOless only works with Go tip, which has a fix for a linker issue that causes the build to fail.
-          - architecture: s390x
-            go-version: tip
             cgo: 0
     steps:
     - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Set OpenSSL config and prove FIPS
       run: |
         sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-        go test -v -count 0 . | grep -q "FIPS enabled: true"
-      if: ${{ matrix.openssl-version == '3.0.1' }}
+        go test -v -count 0 ./openssl | grep -q "FIPS enabled: true"
+      if: ${{ matrix.openssl-version == '3.0.1' || matrix.openssl-version == '3.5.6' }}
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
     - name: Run Test

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -270,6 +270,7 @@ int EVP_CIPHER_CTX_set_key_length(_EVP_CIPHER_CTX_PTR x, int keylen);
 void EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR arg0);
 int EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr);
 int EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc);
+int EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, const unsigned char *key, const unsigned char *iv, int enc, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));
 int EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR ctx, const _EVP_CIPHER_PTR type, _ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv);
 int EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) __attribute__((noescape,nocallback));

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -297,6 +297,7 @@ int EVP_PKEY_get_octet_string_param(const _EVP_PKEY_PTR pkey, const char *key_na
 int EVP_PKEY_up_ref(_EVP_PKEY_PTR key);
 int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int len) __attribute__((tag("3")));
+int EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len) __attribute__((tag("111"),noescape,nocallback));
 int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -128,6 +128,7 @@ int (*_g_EVP_PKEY_CTX_set1_hkdf_key)(_EVP_PKEY_CTX_PTR, const unsigned char*, in
 int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
 int (*_g_EVP_PKEY_CTX_set_hkdf_mode)(_EVP_PKEY_CTX_PTR, int);
+int (*_g_EVP_PKEY_CTX_set_params)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 _EVP_PKEY_PTR (*_g_EVP_PKEY_Q_keygen)(_OSSL_LIB_CTX_PTR, const char*, const char*, ...);
 int (*_g_EVP_PKEY_assign)(_EVP_PKEY_PTR, int, void*);
 int (*_g_EVP_PKEY_decapsulate)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
@@ -544,6 +545,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_salt)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_md)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_mode)
+	__mkcgo__dlsym(EVP_PKEY_CTX_set_params)
 	__mkcgo__dlsym(EVP_PKEY_Q_keygen)
 	__mkcgo__dlsym(EVP_PKEY_decapsulate)
 	__mkcgo__dlsym(EVP_PKEY_decapsulate_init)
@@ -618,6 +620,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_PKEY_CTX_set1_hkdf_salt = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_md = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_mode = NULL;
+	_g_EVP_PKEY_CTX_set_params = NULL;
 	_g_EVP_PKEY_Q_keygen = NULL;
 	_g_EVP_PKEY_decapsulate = NULL;
 	_g_EVP_PKEY_decapsulate_init = NULL;
@@ -1419,6 +1422,12 @@ int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR _arg0, const _EVP_MD_PTR _
 
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, uintptr_t *_err_state) {
 	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, uintptr_t *_err_state) {
+	int _ret = _g_EVP_PKEY_CTX_set_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -64,6 +64,7 @@ _EVP_CIPHER_PTR (*_g_EVP_CIPHER_fetch)(_OSSL_LIB_CTX_PTR, const char*, const cha
 const char* (*_g_EVP_CIPHER_get0_name)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CIPHER_get_block_size)(const _EVP_CIPHER_PTR);
 int (*_g_EVP_CipherInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int);
+int (*_g_EVP_CipherInit_ex2)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR);
 int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
 int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
@@ -507,6 +508,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_CIPHER_fetch)
 	__mkcgo__dlsym(EVP_CIPHER_get0_name)
 	__mkcgo__dlsym(EVP_CIPHER_get_block_size)
+	__mkcgo__dlsym(EVP_CipherInit_ex2)
 	__mkcgo__dlsym(EVP_KDF_CTX_free)
 	__mkcgo__dlsym(EVP_KDF_CTX_get_kdf_size)
 	__mkcgo__dlsym(EVP_KDF_CTX_new)
@@ -580,6 +582,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_CIPHER_fetch = NULL;
 	_g_EVP_CIPHER_get0_name = NULL;
 	_g_EVP_CIPHER_get_block_size = NULL;
+	_g_EVP_CipherInit_ex2 = NULL;
 	_g_EVP_KDF_CTX_free = NULL;
 	_g_EVP_KDF_CTX_get_kdf_size = NULL;
 	_g_EVP_KDF_CTX_new = NULL;
@@ -1056,6 +1059,12 @@ int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR _arg0) {
 
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, int _arg5, uintptr_t *_err_state) {
 	int _ret = _g_EVP_CipherInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, const unsigned char* _arg2, const unsigned char* _arg3, int _arg4, const _OSSL_PARAM_PTR _arg5, uintptr_t *_err_state) {
+	int _ret = _g_EVP_CipherInit_ex2(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -239,6 +239,7 @@ int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR, const unsigned char*, i
 int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, uintptr_t *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, uintptr_t *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR, int, uintptr_t *);
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR, const char*, const char*, const char*, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -175,6 +175,7 @@ _EVP_CIPHER_PTR _mkcgo_EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR, const char*, const ch
 const char* _mkcgo_EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR);
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, int, uintptr_t *);
+int _mkcgo_EVP_CipherInit_ex2(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, const unsigned char*, const unsigned char*, int, const _OSSL_PARAM_PTR, uintptr_t *);
 int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, uintptr_t *);
 int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, uintptr_t *);
 int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -373,6 +373,12 @@ func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGIN
 	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex", uintptr(_err))
 }
 
+func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_CipherInit_ex2(ctx, __type, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc), params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_CipherInit_ex2", uintptr(_err))
+}
+
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl), mkcgoNoEscape(&_err))

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -733,6 +733,12 @@ func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error
 	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", uintptr(_err))
 }
 
+func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_PKEY_CTX_set_params(ctx, params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_params", uintptr(_err))
+}
+
 func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_PKEY_Q_keygen_EC(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), (*C.char)(unsafe.Pointer(arg1)), mkcgoNoEscape(&_err))

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -908,6 +908,14 @@ func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", _err)
 }
 
+var _mkcgo_EVP_PKEY_CTX_set_params uintptr
+
+func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_params", _err)
+}
+
 var _mkcgo_EVP_PKEY_Q_keygen uintptr
 
 func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
@@ -2142,6 +2150,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = dlsym(handle, "EVP_PKEY_CTX_set1_hkdf_salt\x00", false)
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_md\x00", false)
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_mode\x00", false)
+	_mkcgo_EVP_PKEY_CTX_set_params = dlsym(handle, "EVP_PKEY_CTX_set_params\x00", false)
 	_mkcgo_EVP_PKEY_Q_keygen = dlsym(handle, "EVP_PKEY_Q_keygen\x00", false)
 	_mkcgo_EVP_PKEY_decapsulate = dlsym(handle, "EVP_PKEY_decapsulate\x00", false)
 	_mkcgo_EVP_PKEY_decapsulate_init = dlsym(handle, "EVP_PKEY_decapsulate_init\x00", false)
@@ -2216,6 +2225,7 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = 0
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = 0
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = 0
+	_mkcgo_EVP_PKEY_CTX_set_params = 0
 	_mkcgo_EVP_PKEY_Q_keygen = 0
 	_mkcgo_EVP_PKEY_decapsulate = 0
 	_mkcgo_EVP_PKEY_decapsulate_init = 0

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -415,6 +415,14 @@ func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGIN
 	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", _err)
 }
 
+var _mkcgo_EVP_CipherInit_ex2 uintptr
+
+func EVP_CipherInit_ex2(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, key *byte, iv *byte, enc int32, params OSSL_PARAM_PTR) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex2, uintptr(ctx), uintptr(__type), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_CipherInit_ex2", _err)
+}
+
 var _mkcgo_EVP_CipherUpdate uintptr
 
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
@@ -2098,6 +2106,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_CIPHER_fetch = dlsym(handle, "EVP_CIPHER_fetch\x00", false)
 	_mkcgo_EVP_CIPHER_get0_name = dlsym(handle, "EVP_CIPHER_get0_name\x00", false)
 	_mkcgo_EVP_CIPHER_get_block_size = dlsym(handle, "EVP_CIPHER_get_block_size\x00", false)
+	_mkcgo_EVP_CipherInit_ex2 = dlsym(handle, "EVP_CipherInit_ex2\x00", false)
 	_mkcgo_EVP_KDF_CTX_free = dlsym(handle, "EVP_KDF_CTX_free\x00", false)
 	_mkcgo_EVP_KDF_CTX_get_kdf_size = dlsym(handle, "EVP_KDF_CTX_get_kdf_size\x00", false)
 	_mkcgo_EVP_KDF_CTX_new = dlsym(handle, "EVP_KDF_CTX_new\x00", false)
@@ -2171,6 +2180,7 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_CIPHER_fetch = 0
 	_mkcgo_EVP_CIPHER_get0_name = 0
 	_mkcgo_EVP_CIPHER_get_block_size = 0
+	_mkcgo_EVP_CipherInit_ex2 = 0
 	_mkcgo_EVP_KDF_CTX_free = 0
 	_mkcgo_EVP_KDF_CTX_get_kdf_size = 0
 	_mkcgo_EVP_KDF_CTX_new = 0

--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 )
 
-//go:generate go run github.com/golang-fips/openssl/v2/cmd/genaesmodes -in aes.go -modes CBC,CTR,GCM -out zaes.go
-//go:generate go run github.com/golang-fips/openssl/v2/cmd/gentestvectors -out vectors_test.go
+//go:generate go run github.com/microsoft/go-crypto-openssl/cmd/genaesmodes -in aes.go -modes CBC,CTR,GCM -out zaes.go
+//go:generate go run github.com/microsoft/go-crypto-openssl/cmd/gentestvectors -out vectors_test.go
 
 // Steps to support a new AES mode, e.g. `FOO`:
 // 1. Add `FOO` to the list of modes in the `genaesmodes` command.

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -619,9 +619,6 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if err != nil {
 		return nil, err
 	}
-	if params != nil {
-		defer ossl.OSSL_PARAM_free(params)
-	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -655,15 +652,23 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	return ctx, nil
 }
 
+var cipherEncryptCheckParams = sync.OnceValues(func() (ossl.OSSL_PARAM_PTR, error) {
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
+	}
+	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
+	return bld.build()
+})
+
 func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
 	if encrypt != cipherOpEncrypt || major() == 1 {
 		return nil, nil
 	}
-	bld := newParamBuilder()
+	// The returned params are cached for the lifetime of the process and must not be freed by callers.
 	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
 	// This check is done at the Go crypto level.
-	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
-	return bld.build()
+	return cipherEncryptCheckParams()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/cipher.go
+++ b/openssl/cipher.go
@@ -615,6 +615,13 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if cipher == nil {
 		panic("crypto/cipher: unsupported cipher: " + kind.String())
 	}
+	params, err := cipherInitParams(encrypt)
+	if err != nil {
+		return nil, err
+	}
+	if params != nil {
+		defer ossl.OSSL_PARAM_free(params)
+	}
 	ctx, err := ossl.EVP_CIPHER_CTX_new()
 	if err != nil {
 		return nil, err
@@ -637,10 +644,26 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 		cipher = nil
 	}
-	if _, err := ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
+	if params != nil {
+		_, err = ossl.EVP_CipherInit_ex2(ctx, cipher, base(key), base(iv), int32(encrypt), params)
+	} else {
+		_, err = ossl.EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt))
+	}
+	if err != nil {
 		return nil, err
 	}
 	return ctx, nil
+}
+
+func cipherInitParams(encrypt cipherOp) (ossl.OSSL_PARAM_PTR, error) {
+	if encrypt != cipherOpEncrypt || major() == 1 {
+		return nil, nil
+	}
+	bld := newParamBuilder()
+	// Setting the FIPS encrypt check to 0 allows encryption to proceed even if the key is not approved for use in FIPS mode.
+	// This check is done at the Go crypto level.
+	bld.addInt32(_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK, 0)
+	return bld.build()
 }
 
 // The following two functions are a mirror of golang.org/x/crypto/internal/subtle.

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -89,6 +89,13 @@ const ( //checkheader:ignore
 	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1   cString = "rsa-coefficient1\x00"
 	_OSSL_PKEY_PARAM_ML_KEM_SEED        cString = "seed\x00"
 
+	// Signature parameters
+	_OSSL_SIGNATURE_PARAM_DIGEST                     cString = "digest\x00"
+	_OSSL_SIGNATURE_PARAM_PAD_MODE                   cString = "pad-mode\x00"
+	_OSSL_SIGNATURE_PARAM_PSS_SALTLEN                cString = "saltlen\x00"
+	_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK cString = "rsa-pss-saltlen-check\x00"
+	_OSSL_PKEY_RSA_PAD_MODE_PSS                      cString = "pss\x00"
+
 	// MAC parameters
 	_OSSL_MAC_PARAM_DIGEST cString = "digest\x00"
 )

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -59,7 +59,8 @@ const ( //checkheader:ignore
 	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 
-	// Cipher parameters
+	// KDF FIPS parameters
+	_OSSL_KDF_PARAM_FIPS_KEY_CHECK        cString = "key-check\x00"
 	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
 
 	// TLS3-KDF parameters

--- a/openssl/const.go
+++ b/openssl/const.go
@@ -59,6 +59,9 @@ const ( //checkheader:ignore
 	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
 	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
 
+	// Cipher parameters
+	_OSSL_CIPHER_PARAM_FIPS_ENCRYPT_CHECK cString = "encrypt-check\x00"
+
 	// TLS3-KDF parameters
 	_OSSL_KDF_PARAM_PREFIX cString = "prefix\x00"
 	_OSSL_KDF_PARAM_LABEL  cString = "label\x00"

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -323,19 +323,37 @@ func setPSSPadding(ctx ossl.EVP_PKEY_CTX_PTR, saltLen int32, ch crypto.Hash) err
 	if alg == nil {
 		return errors.New("crypto/rsa: unsupported hash function")
 	}
-	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
-		return err
-	}
-	// setPadding must happen after setting EVP_PKEY_CTRL_MD.
-	if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
-		return err
-	}
-	if saltLen != 0 {
-		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+	switch major() {
+	case 1:
+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
 			return err
 		}
+		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
+		if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PADDING, ossl.RSA_PKCS1_PSS_PADDING, nil); err != nil {
+			return err
+		}
+		if saltLen != 0 {
+			if _, err := ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		bld := newParamBuilder()
+		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
+		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
+		if saltLen != 0 {
+			bld.addInt32(_OSSL_SIGNATURE_PARAM_PSS_SALTLEN, saltLen)
+		}
+		bld.addInt32(_OSSL_SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK, 0)
+		params, err := bld.build()
+		if err != nil {
+			return err
+		}
+		defer ossl.OSSL_PARAM_free(params)
+		_, err = ossl.EVP_PKEY_CTX_set_params(ctx, params)
+		return err
 	}
-	return nil
 }
 
 func setPKCS1Padding(ctx ossl.EVP_PKEY_CTX_PTR, ch crypto.Hash) error {

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -339,7 +339,10 @@ func setPSSPadding(ctx ossl.EVP_PKEY_CTX_PTR, saltLen int32, ch crypto.Hash) err
 		}
 		return nil
 	default:
-		bld := newParamBuilder()
+		bld, err := newParamBuilder()
+		if err != nil {
+			return err
+		}
 		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_DIGEST, ossl.EVP_MD_get0_name(alg.md), 0)
 		bld.addUTF8String(_OSSL_SIGNATURE_PARAM_PAD_MODE, _OSSL_PKEY_RSA_PAD_MODE_PSS.ptr(), 0)
 		if saltLen != 0 {

--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -401,6 +401,7 @@ func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, 
 	if err != nil {
 		return ctx, err
 	}
+	bld.addInt32(_OSSL_KDF_PARAM_FIPS_KEY_CHECK, 0)
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 	bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)

--- a/openssl/hkdf_test.go
+++ b/openssl/hkdf_test.go
@@ -354,6 +354,7 @@ func TestHKDFMultiRead(t *testing.T) {
 		hkdf, err := newHKDF(tt.hash, tt.master, tt.salt, tt.info)
 		if err != nil {
 			t.Errorf("test %d: error creating HKDF: %v.", i, err)
+			continue
 		}
 		out := make([]byte, len(tt.out))
 


### PR DESCRIPTION
Backport of #17 to ms-go1.26-support.

Includes a 1.26-only fix for the openssl/aes.go go:generate module paths; main and ms-go1.25-support already use the github.com/microsoft/go-crypto-openssl path, and this lets the workflow generation check resolve the local generators.

Validation:
- go test ./openssl -run 'TestDES|TestRSASignVerifyRSAPSS_SaltLength|TestRSAPSS' -count=1
- go test ./...
- go generate ./openssl

Note: go generate ./... is blocked on this Windows machine by internal/fakecgo's update_tool.exe requiring elevation.