### PR TITLE
Return concrete Hash from hash constructors

### DIFF
--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -22,7 +22,7 @@ var cacheMD sync.Map
 // This is used to avoid aborting the program when calling
 // an unsupported hash function. It is the caller's responsibility
 // to check the returned value.
-func hashFuncHash(fn func() hash.Hash) (h hash.Hash, err error) {
+func hashFuncHash[H hash.Hash](fn func() H) (h hash.Hash, err error) {
 	defer func() {
 		r := recover()
 		if r == nil {
@@ -59,7 +59,7 @@ func hashToCryptoHash(h hash.Hash) crypto.Hash {
 
 // hashFuncToMD converts a hash.Hash function to a GOossl.EVP_MD_PTR.
 // See [hashFuncHash] for details on error handling.
-func hashFuncToMD(fn func() hash.Hash) (ossl.EVP_MD_PTR, error) {
+func hashFuncToMD[H hash.Hash](fn func() H) (ossl.EVP_MD_PTR, error) {
 	h, err := hashFuncHash(fn)
 	if err != nil {
 		return nil, err

--- a/openssl/hash.go
+++ b/openssl/hash.go
@@ -34,8 +34,6 @@ const (
 // maxHashSize is the size of SHA52 and SHA3_512, the largest hashes we support.
 const maxHashSize = 64
 
-type HashCloner = hash.Cloner
-
 func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
 	_, err := ossl.EVP_Digest(p, sum, nil, loadHash(ch, true).md, nil)
 	return err == nil
@@ -161,47 +159,47 @@ func SumSHA3_512(p []byte) (sum [64]byte) {
 // NewMD4 returns a new MD4 hash.
 // The returned hash doesn't implement encoding.BinaryMarshaler and
 // encoding.BinaryUnmarshaler.
-func NewMD4() hash.Hash {
+func NewMD4() *Hash {
 	return newHash(crypto.MD4)
 }
 
 // NewMD5 returns a new MD5 hash.
-func NewMD5() hash.Hash {
+func NewMD5() *Hash {
 	return newHash(crypto.MD5)
 }
 
 // NewSHA1 returns a new SHA1 hash.
-func NewSHA1() hash.Hash {
+func NewSHA1() *Hash {
 	return newHash(crypto.SHA1)
 }
 
 // NewSHA224 returns a new SHA224 hash.
-func NewSHA224() hash.Hash {
+func NewSHA224() *Hash {
 	return newHash(crypto.SHA224)
 }
 
 // NewSHA256 returns a new SHA256 hash.
-func NewSHA256() hash.Hash {
+func NewSHA256() *Hash {
 	return newHash(crypto.SHA256)
 }
 
 // NewSHA384 returns a new SHA384 hash.
-func NewSHA384() hash.Hash {
+func NewSHA384() *Hash {
 	return newHash(crypto.SHA384)
 }
 
 // NewSHA512 returns a new SHA512 hash.
-func NewSHA512() hash.Hash {
+func NewSHA512() *Hash {
 	return newHash(crypto.SHA512)
 }
 
 // NewSHA512_224 returns a new SHA512_224 hash.
-func NewSHA512_224() hash.Hash {
+func NewSHA512_224() *Hash {
 	return newHash(crypto.SHA512_224)
 }
 
 // NewSHA512_256 returns a new SHA512_256 hash.
-func NewSHA512_256() hash.Hash {
+func NewSHA512_256() *Hash {
 	return newHash(crypto.SHA512_256)
 }
 
@@ -226,7 +224,7 @@ func NewSHA3_512() *Hash {
 }
 
 var _ hash.Hash = (*Hash)(nil)
-var _ HashCloner = (*Hash)(nil)
+var _ hash.Cloner = (*Hash)(nil)
 
 // FIPSApprovedHash reports whether this hash algorithm is FIPS 140-3 approved.
 func FIPSApprovedHash(h hash.Hash) bool {
@@ -271,7 +269,7 @@ func newHash(ch crypto.Hash) *Hash {
 	// Don't call init() yet, it would be wasteful
 	// if the caller only wants to know the hash type. This
 	// is a common pattern in this package, as some functions
-	// accept a `func() hash.Hash` parameter and call it just
+	// accept a hash constructor parameter and call it just
 	// to know the hash type.
 	return &Hash{alg: loadHash(ch, true)}
 }
@@ -406,7 +404,7 @@ func (h *Hash) Sum(in []byte) []byte {
 // Clone returns a new Hash object that is a deep clone of itself.
 // The duplicate object contains all state and data contained in the
 // original object at the point of duplication.
-func (h *Hash) Clone() (HashCloner, error) {
+func (h *Hash) Clone() (hash.Cloner, error) {
 	h2 := &Hash{alg: h.alg, nbuf: h.nbuf}
 	copy(h2.buf[:h.nbuf], h.buf[:h.nbuf])
 	if h.ctx != nil {

--- a/openssl/hash.go
+++ b/openssl/hash.go
@@ -157,8 +157,7 @@ func SumSHA3_512(p []byte) (sum [64]byte) {
 }
 
 // NewMD4 returns a new MD4 hash.
-// The returned hash doesn't implement encoding.BinaryMarshaler and
-// encoding.BinaryUnmarshaler.
+// State marshaling and unmarshaling return errors.ErrUnsupported.
 func NewMD4() *Hash {
 	return newHash(crypto.MD4)
 }

--- a/openssl/hash_buffer_test.go
+++ b/openssl/hash_buffer_test.go
@@ -5,7 +5,6 @@ package openssl_test
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/microsoft/go-crypto-openssl/openssl"
@@ -34,7 +33,7 @@ func TestHashBufferingWithClone(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Write some data that stays in buffer
-			h := openssl.NewSHA256().(openssl.HashCloner)
+			h := openssl.NewSHA256()
 			h.Write(tt.data)
 
 			// Clone while data is buffered
@@ -219,7 +218,7 @@ func TestHashBufferingWriteByte(t *testing.T) {
 	// Write bytes one at a time
 	data := []byte("hello")
 	for _, b := range data {
-		if err := h.(io.ByteWriter).WriteByte(b); err != nil {
+		if err := h.WriteByte(b); err != nil {
 			t.Fatalf("WriteByte failed: %v", err)
 		}
 	}
@@ -244,7 +243,7 @@ func TestHashBufferingWriteString(t *testing.T) {
 	// Write string
 	const s = "hello world"
 
-	n, err := h.(io.StringWriter).WriteString(s)
+	n, err := h.WriteString(s)
 	if err != nil || n != len(s) {
 		t.Fatalf("WriteString returned (%v, %d), want (nil, %d)", err, n, len(s))
 	}
@@ -344,7 +343,7 @@ func TestHashBufferingMixedSizes(t *testing.T) {
 // TestHashBufferingCloneAtBufferBoundary tests cloning when buffer is exactly full
 func TestHashBufferingCloneAtBufferBoundary(t *testing.T) {
 	t.Parallel()
-	h := openssl.NewSHA256().(openssl.HashCloner)
+	h := openssl.NewSHA256()
 
 	// Write exactly openssl.HashBufSize bytes
 	data := bytes.Repeat([]byte("a"), openssl.HashBufSize)

--- a/openssl/hash_test.go
+++ b/openssl/hash_test.go
@@ -131,7 +131,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 
 			state, err := hashMarshaler.MarshalBinary()
 			if err != nil {
-				if strings.Contains(err.Error(), "hash state is not marshallable") {
+				if errors.Is(err, errors.ErrUnsupported) || strings.Contains(err.Error(), "hash state is not marshallable") {
 					t.Skip("BinaryMarshaler not supported")
 				}
 				t.Fatalf("MarshalBinary failed: %v", err)

--- a/openssl/hash_test.go
+++ b/openssl/hash_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding"
 	"errors"
 	"hash"
-	"io"
 	"runtime"
 	"strings"
 	"testing"
@@ -23,7 +22,7 @@ import (
 	"github.com/microsoft/go-crypto-openssl/openssl"
 )
 
-func cryptoToHash(h crypto.Hash) func() hash.Hash {
+func cryptoToHash(h crypto.Hash) func() *openssl.Hash {
 	switch h {
 	case crypto.MD4:
 		return openssl.NewMD4
@@ -44,13 +43,13 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 	case crypto.SHA512_256:
 		return openssl.NewSHA512_256
 	case crypto.SHA3_224:
-		return func() hash.Hash { return openssl.NewSHA3_224() }
+		return openssl.NewSHA3_224
 	case crypto.SHA3_256:
-		return func() hash.Hash { return openssl.NewSHA3_256() }
+		return openssl.NewSHA3_256
 	case crypto.SHA3_384:
-		return func() hash.Hash { return openssl.NewSHA3_384() }
+		return openssl.NewSHA3_384
 	case crypto.SHA3_512:
-		return func() hash.Hash { return openssl.NewSHA3_512() }
+		return openssl.NewSHA3_512
 	}
 	return nil
 }
@@ -124,10 +123,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 				t.Skip("hash not supported")
 			}
 
-			hashMarshaler, ok := cryptoToHash(ch)().(hashEncoding)
-			if !ok {
-				t.Fatal("BinaryMarshaler not supported")
-			}
+			hashMarshaler := cryptoToHash(ch)()
 
 			if _, err := hashMarshaler.Write(msg); err != nil {
 				t.Fatalf("Write failed: %v", err)
@@ -141,7 +137,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 				t.Fatalf("MarshalBinary failed: %v", err)
 			}
 
-			hashUnmarshaler := cryptoToHash(ch)().(hashEncoding)
+			hashUnmarshaler := cryptoToHash(ch)()
 			if err := hashUnmarshaler.UnmarshalBinary(state); err != nil {
 				t.Fatalf("UnmarshalBinary failed: %v", err)
 			}
@@ -181,10 +177,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 				t.Skip("not supported")
 			}
 
-			hashWithBinaryAppender, ok := cryptoToHash(ch)().(hashEncodingAppender)
-			if !ok {
-				t.Fatal("AppendBinary not supported")
-			}
+			hashWithBinaryAppender := cryptoToHash(ch)()
 
 			// Create a slice with 10 elements
 			prebuiltSlice := make([]byte, 10)
@@ -213,10 +206,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 			// Use only the newly appended part of the slice
 			appendedState := state[10:]
 
-			h2, ok := cryptoToHash(ch)().(hashEncoding)
-			if !ok {
-				t.Skip("not supported")
-			}
+			h2 := cryptoToHash(ch)()
 
 			if err := h2.UnmarshalBinary(appendedState); err != nil {
 				t.Errorf("could not unmarshal: %v", err)
@@ -236,7 +226,7 @@ func TestHash_Clone(t *testing.T) {
 			if !openssl.SupportsHash(ch) {
 				t.Skip("not supported")
 			}
-			h := cryptoToHash(ch)().(openssl.HashCloner)
+			h := cryptoToHash(ch)()
 			_, err := h.Write(msg)
 			if err != nil {
 				t.Fatal(err)
@@ -285,10 +275,7 @@ func TestHash_ByteWriter(t *testing.T) {
 			if !openssl.SupportsHash(ch) {
 				t.Skip("not supported")
 			}
-			bwh := cryptoToHash(ch)().(interface {
-				hash.Hash
-				io.ByteWriter
-			})
+			bwh := cryptoToHash(ch)()
 			initSum := bwh.Sum(nil)
 			for i := range len(msg) {
 				bwh.WriteByte(msg[i])
@@ -312,8 +299,8 @@ func TestHash_StringWriter(t *testing.T) {
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
-			h.(io.StringWriter).WriteString("")
-			h.(io.StringWriter).WriteString(string(msg))
+			h.WriteString("")
+			h.WriteString(string(msg))
 			h.Reset()
 			sum := h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
@@ -544,9 +531,9 @@ func TestHashAllocationsWithTypeAsserts(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		h := openssl.NewSHA256()
 		h.Write([]byte{1, 2, 3})
-		marshaled, _ := h.(encoding.BinaryMarshaler).MarshalBinary()
-		marshaled, _ = h.(encoding.BinaryAppender).AppendBinary(marshaled[:0])
-		h.(encoding.BinaryUnmarshaler).UnmarshalBinary(marshaled)
+		marshaled, _ := h.MarshalBinary()
+		marshaled, _ = h.AppendBinary(marshaled[:0])
+		h.UnmarshalBinary(marshaled)
 	})
 	const maxAllocs = 2
 	if allocs > float64(maxAllocs) {

--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -83,7 +83,7 @@ var hkdfAllZerosSalt [64]byte
 // ExtractHDKF implements the HDKF extract step.
 // If salt is nil, then this function replaces it internally with a buffer of
 // zeros whose length equals the output length of the specified hash algorithm.
-func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
+func ExtractHKDF[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {
 	if !SupportsHKDF() {
 		return nil, errUnsupportedVersion()
 	}
@@ -142,7 +142,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 }
 
 // ExpandHKDF derives a key from the given hash, key, and optional context info.
-func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
+func ExpandHKDF[H hash.Hash](h func() H, pseudorandomKey, info []byte, keyLength int) ([]byte, error) {
 	if !SupportsHKDF() {
 		return nil, errUnsupportedVersion()
 	}
@@ -191,7 +191,7 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte, keyLength int)
 
 // ExpandTLS13KDF derives a key from the given hash, key, label and context. It will use
 // "TLS13-KDF" algorithm to do so.
-func ExpandTLS13KDF(h func() hash.Hash, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
+func ExpandTLS13KDF[H hash.Hash](h func() H, pseudorandomKey, label, context []byte, keyLength int) ([]byte, error) {
 	if !SupportsTLS13KDF() {
 		return nil, errUnsupportedVersion()
 	}

--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -80,7 +80,7 @@ func newHKDFCtx1(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, 
 // used with HKDF.
 var hkdfAllZerosSalt [64]byte
 
-// ExtractHDKF implements the HDKF extract step.
+// ExtractHKDF implements the HKDF extract step.
 // If salt is nil, then this function replaces it internally with a buffer of
 // zeros whose length equals the output length of the specified hash algorithm.
 func ExtractHKDF[H hash.Hash](h func() H, secret, salt []byte) ([]byte, error) {

--- a/openssl/hkdf_test.go
+++ b/openssl/hkdf_test.go
@@ -5,14 +5,13 @@ package openssl_test
 
 import (
 	"bytes"
-	"hash"
 	"testing"
 
 	openssl "github.com/microsoft/go-crypto-openssl/openssl"
 )
 
 type hkdfTest struct {
-	hash   func() hash.Hash
+	hash   func() *openssl.Hash
 	master []byte
 	salt   []byte
 	prk    []byte
@@ -336,7 +335,7 @@ func TestExpandHKDFLimit(t *testing.T) {
 }
 
 type tls13kdfTest struct {
-	hash  func() hash.Hash
+	hash  func() *openssl.Hash
 	prk   []byte
 	label []byte
 	ctx   []byte

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -13,9 +13,9 @@ import (
 )
 
 // NewHMAC returns a new HMAC using OpenSSL.
-// The function h must return a hash implemented by
+// The function fh must return a hash implemented by
 // OpenSSL (for example, [NewSHA256]).
-// If h is not recognized, NewHMAC returns nil.
+// If fh is not recognized, NewHMAC returns nil.
 func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
 	h, _ := hashFuncHash(fh)
 	md := hashToMD(h)

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -14,9 +14,9 @@ import (
 
 // NewHMAC returns a new HMAC using OpenSSL.
 // The function h must return a hash implemented by
-// OpenSSL (for example, h could be openssl.NewSHA256).
+// OpenSSL (for example, [NewSHA256]).
 // If h is not recognized, NewHMAC returns nil.
-func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
+func NewHMAC[H hash.Hash](fh func() H, key []byte) hash.Hash {
 	h, _ := hashFuncHash(fh)
 	md := hashToMD(h)
 	if md == nil {
@@ -233,7 +233,7 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	return append(in, h.sum[:h.size]...)
 }
 
-func (h *opensslHMAC) Clone() (HashCloner, error) {
+func (h *opensslHMAC) Clone() (hash.Cloner, error) {
 	switch major() {
 	case 1:
 		ctx2, err := ossl.HMAC_CTX_new()

--- a/openssl/hmac_test.go
+++ b/openssl/hmac_test.go
@@ -5,7 +5,6 @@ package openssl_test
 
 import (
 	"bytes"
-	"hash"
 	"testing"
 
 	"github.com/microsoft/go-crypto-openssl/openssl"
@@ -14,7 +13,7 @@ import (
 func TestHMAC(t *testing.T) {
 	var tests = []struct {
 		name string
-		fn   func() hash.Hash
+		fn   func() *openssl.Hash
 	}{
 		{"sha1", openssl.NewSHA1},
 		{"sha224", openssl.NewSHA224},

--- a/openssl/pbkdf2.go
+++ b/openssl/pbkdf2.go
@@ -33,7 +33,7 @@ var fetchPBKDF2 = sync.OnceValues(func() (ossl.EVP_KDF_PTR, error) {
 	return kdf, nil
 })
 
-func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byte, error) {
+func PBKDF2[H hash.Hash](password, salt []byte, iter, keyLen int, fh func() H) ([]byte, error) {
 	h, err := hashFuncHash(fh)
 	if err != nil {
 		return nil, err

--- a/openssl/pbkdf2_test.go
+++ b/openssl/pbkdf2_test.go
@@ -138,7 +138,7 @@ var sha256TestVectors = []testVector{
 	},
 }
 
-func testHash(t *testing.T, h func() hash.Hash, hashName string, vectors []testVector) {
+func testHash[H hash.Hash](t *testing.T, h func() H, hashName string, vectors []testVector) {
 	if !openssl.SupportsPBKDF2() {
 		t.Skip("PBKDF2 is not supported")
 	}
@@ -173,7 +173,7 @@ func TestPBKDF2WithUnsupportedHash(t *testing.T) {
 	}
 }
 
-func benchmark(b *testing.B, h func() hash.Hash) {
+func benchmark[H hash.Hash](b *testing.B, h func() H) {
 	password := make([]byte, h().Size())
 	salt := make([]byte, 8)
 	var err error

--- a/openssl/tls1prf.go
+++ b/openssl/tls1prf.go
@@ -23,10 +23,10 @@ func SupportsTLS1PRF() bool {
 	}
 }
 
-// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil,
+// TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if fh is nil,
 // else it implements the TLS 1.2 pseudo-random function.
 // The pseudo-random number will be written to result and will be of length len(result).
-func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
+func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error {
 	var md ossl.EVP_MD_PTR
 	if fh == nil {
 		// TLS 1.0/1.1 PRF doesn't allow to specify the hash function,

--- a/openssl/tls1prf.go
+++ b/openssl/tls1prf.go
@@ -25,12 +25,14 @@ func SupportsTLS1PRF() bool {
 
 // TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if fh is nil,
 // else it implements the TLS 1.2 pseudo-random function.
+// To use TLS 1.0/1.1 mode with nil fh, specify the type parameter explicitly,
+// for example TLS1PRF[hash.Hash](result, secret, label, seed, nil).
 // The pseudo-random number will be written to result and will be of length len(result).
 func TLS1PRF[H hash.Hash](result, secret, label, seed []byte, fh func() H) error {
 	var md ossl.EVP_MD_PTR
 	if fh == nil {
 		// TLS 1.0/1.1 PRF doesn't allow to specify the hash function,
-		// it always uses MD5SHA1. If h is nil, then assume
+		// it always uses MD5SHA1. If fh is nil, then assume
 		// that the caller wants to use TLS 1.0/1.1 PRF.
 		// OpenSSL detects this case by checking if the hash
 		// function is MD5SHA1.

--- a/openssl/tls1prf_test.go
+++ b/openssl/tls1prf_test.go
@@ -158,9 +158,14 @@ func TestTLS1PRF(t *testing.T) {
 				t.Skip("skipping: hash not supported")
 			}
 			result := make([]byte, len(tt.out))
-			err := openssl.TLS1PRF(result, tt.secret, tt.label, tt.seed, cryptoToHash(tt.hash))
+			var err error
+			if tt.hash == crypto.MD5SHA1 {
+				err = openssl.TLS1PRF[*openssl.Hash](result, tt.secret, tt.label, tt.seed, nil)
+			} else {
+				err = openssl.TLS1PRF(result, tt.secret, tt.label, tt.seed, cryptoToHash(tt.hash))
+			}
 			if err != nil {
-				t.Fatalf("error deriving TLS 1.2 PRF: %v.", err)
+				t.Fatalf("error deriving TLS PRF: %v.", err)
 			}
 			if !bytes.Equal(result, tt.out) {
 				t.Errorf("incorrect key output: have %v, need %v.", result, tt.out)


### PR DESCRIPTION
## Summary
- Return `*Hash` from the OpenSSL `New*` hash constructors.
- Parameterize hash factory consumers with `H hash.Hash` so concrete constructors can be passed directly.
- Simplify related tests now that callers no longer need adapter wrappers or type assertions.

These changes are a step in the direction of moving away from the BoringCrypto API and into the upstream fips140 module API.

## Testing
- `go test ./openssl`