### PR TITLE
Implement Equal via native EVP_PKEY_eq for ML-DSA

### DIFF
--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -303,6 +303,7 @@ int EVP_PKEY_set1_encoded_public_key(_EVP_PKEY_PTR pkey, const unsigned char *pu
 size_t EVP_PKEY_get1_encoded_public_key(_EVP_PKEY_PTR pkey, unsigned char **ppub) __attribute__((tag("3")));
 int EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR pkey, const char *key_name, _BIGNUM_PTR *bn) __attribute__((tag("3"),noescape,nocallback));
 int EVP_PKEY_get_octet_string_param(const _EVP_PKEY_PTR pkey, const char *key_name, unsigned char *buf, size_t buf_len, size_t *out_len) __attribute__((tag("3"),slice("buf","buf_len")));
+int EVP_PKEY_eq(const _EVP_PKEY_PTR a, const _EVP_PKEY_PTR b) __attribute__((tag("3"),noescape,nocallback));
 int EVP_PKEY_up_ref(_EVP_PKEY_PTR key);
 int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int labellen) __attribute__((tag("3"),slice("label","labellen")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -144,6 +144,7 @@ int (*_g_EVP_PKEY_encapsulate)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, unsig
 int (*_g_EVP_PKEY_encapsulate_init)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 int (*_g_EVP_PKEY_encrypt)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
 int (*_g_EVP_PKEY_encrypt_init)(_EVP_PKEY_CTX_PTR);
+int (*_g_EVP_PKEY_eq)(const _EVP_PKEY_PTR, const _EVP_PKEY_PTR);
 void (*_g_EVP_PKEY_free)(_EVP_PKEY_PTR);
 int (*_g_EVP_PKEY_fromdata)(_EVP_PKEY_CTX_PTR, _EVP_PKEY_PTR*, int, _OSSL_PARAM_PTR);
 int (*_g_EVP_PKEY_fromdata_init)(_EVP_PKEY_CTX_PTR);
@@ -543,6 +544,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_PKEY_decapsulate_init)
 	__mkcgo__dlsym(EVP_PKEY_encapsulate)
 	__mkcgo__dlsym(EVP_PKEY_encapsulate_init)
+	__mkcgo__dlsym(EVP_PKEY_eq)
 	__mkcgo__dlsym(EVP_PKEY_fromdata)
 	__mkcgo__dlsym(EVP_PKEY_fromdata_init)
 	__mkcgo__dlsym(EVP_PKEY_get1_encoded_public_key)
@@ -618,6 +620,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_PKEY_decapsulate_init = NULL;
 	_g_EVP_PKEY_encapsulate = NULL;
 	_g_EVP_PKEY_encapsulate_init = NULL;
+	_g_EVP_PKEY_eq = NULL;
 	_g_EVP_PKEY_fromdata = NULL;
 	_g_EVP_PKEY_fromdata_init = NULL;
 	_g_EVP_PKEY_get1_encoded_public_key = NULL;
@@ -1535,6 +1538,12 @@ int _mkcgo_EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_
 
 int _mkcgo_EVP_PKEY_encrypt_init(_EVP_PKEY_CTX_PTR _arg0, uintptr_t *_err_state) {
 	int _ret = _g_EVP_PKEY_encrypt_init(_arg0);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_EVP_PKEY_eq(const _EVP_PKEY_PTR _arg0, const _EVP_PKEY_PTR _arg1, uintptr_t *_err_state) {
+	int _ret = _g_EVP_PKEY_eq(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -266,6 +266,7 @@ int _mkcgo_EVP_PKEY_encapsulate(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, unsi
 int _mkcgo_EVP_PKEY_encapsulate_init(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, uintptr_t *);
 int _mkcgo_EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t, uintptr_t *);
 int _mkcgo_EVP_PKEY_encrypt_init(_EVP_PKEY_CTX_PTR, uintptr_t *);
+int _mkcgo_EVP_PKEY_eq(const _EVP_PKEY_PTR, const _EVP_PKEY_PTR, uintptr_t *);
 void _mkcgo_EVP_PKEY_free(_EVP_PKEY_PTR);
 int _mkcgo_EVP_PKEY_fromdata(_EVP_PKEY_CTX_PTR, _EVP_PKEY_PTR*, int, _OSSL_PARAM_PTR, uintptr_t *);
 int _mkcgo_EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -66,6 +66,8 @@ package ossl
 #cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_X25519
 #cgo noescape _mkcgo_EVP_PKEY_derive
 #cgo nocallback _mkcgo_EVP_PKEY_derive
+#cgo noescape _mkcgo_EVP_PKEY_eq
+#cgo nocallback _mkcgo_EVP_PKEY_eq
 #cgo noescape _mkcgo_EVP_PKEY_get_bn_param
 #cgo nocallback _mkcgo_EVP_PKEY_get_bn_param
 #cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key
@@ -956,6 +958,12 @@ func EVP_PKEY_encrypt_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_PKEY_encrypt_init(arg0, mkcgoNoEscape(&_err))
 	return int32(_ret), newMkcgoErr("EVP_PKEY_encrypt_init", uintptr(_err))
+}
+
+func EVP_PKEY_eq(a EVP_PKEY_PTR, b EVP_PKEY_PTR) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_PKEY_eq(a, b, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_PKEY_eq", uintptr(_err))
 }
 
 func EVP_PKEY_free(arg0 EVP_PKEY_PTR) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -1112,6 +1112,14 @@ func EVP_PKEY_encrypt_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	return int32(r0), newMkcgoErr("EVP_PKEY_encrypt_init", _err)
 }
 
+var _mkcgo_EVP_PKEY_eq uintptr
+
+func EVP_PKEY_eq(a EVP_PKEY_PTR, b EVP_PKEY_PTR) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_eq, uintptr(a), uintptr(b), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_PKEY_eq", _err)
+}
+
 var _mkcgo_EVP_PKEY_free uintptr
 
 func EVP_PKEY_free(arg0 EVP_PKEY_PTR) {
@@ -2222,6 +2230,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_PKEY_decapsulate_init = dlsym(handle, "EVP_PKEY_decapsulate_init\x00", false)
 	_mkcgo_EVP_PKEY_encapsulate = dlsym(handle, "EVP_PKEY_encapsulate\x00", false)
 	_mkcgo_EVP_PKEY_encapsulate_init = dlsym(handle, "EVP_PKEY_encapsulate_init\x00", false)
+	_mkcgo_EVP_PKEY_eq = dlsym(handle, "EVP_PKEY_eq\x00", false)
 	_mkcgo_EVP_PKEY_fromdata = dlsym(handle, "EVP_PKEY_fromdata\x00", false)
 	_mkcgo_EVP_PKEY_fromdata_init = dlsym(handle, "EVP_PKEY_fromdata_init\x00", false)
 	_mkcgo_EVP_PKEY_get1_encoded_public_key = dlsym(handle, "EVP_PKEY_get1_encoded_public_key\x00", false)
@@ -2297,6 +2306,7 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_PKEY_decapsulate_init = 0
 	_mkcgo_EVP_PKEY_encapsulate = 0
 	_mkcgo_EVP_PKEY_encapsulate_init = 0
+	_mkcgo_EVP_PKEY_eq = 0
 	_mkcgo_EVP_PKEY_fromdata = 0
 	_mkcgo_EVP_PKEY_fromdata_init = 0
 	_mkcgo_EVP_PKEY_get1_encoded_public_key = 0

--- a/openssl/mldsa.go
+++ b/openssl/mldsa.go
@@ -177,6 +177,26 @@ func (key *PrivateKeyMLDSA) Bytes() []byte {
 	return key.seed[:]
 }
 
+// Equal reports whether key and other represent the same private key.
+func (key *PrivateKeyMLDSA) Equal(other *PrivateKeyMLDSA) bool {
+	if other == nil {
+		return false
+	}
+	a, err := createMLDSAPrivateKey(key.params.keyType, key.seed[:])
+	if err != nil {
+		return false
+	}
+	defer ossl.EVP_PKEY_free(a)
+	b, err := createMLDSAPrivateKey(other.params.keyType, other.seed[:])
+	if err != nil {
+		return false
+	}
+	defer ossl.EVP_PKEY_free(b)
+	// Equal cannot return an error; treat any failure as inequality.
+	ret, _ := ossl.EVP_PKEY_eq(a, b)
+	return ret == 1
+}
+
 // Parameters returns the parameters associated with this private key.
 func (key *PrivateKeyMLDSA) Parameters() MLDSAParameters { return key.params }
 
@@ -232,6 +252,26 @@ func NewPublicKeyMLDSA(params MLDSAParameters, publicKey []byte) (*PublicKeyMLDS
 // Bytes returns the public key encoding.
 func (key *PublicKeyMLDSA) Bytes() []byte {
 	return key.bytes[:key.params.publicKeySize]
+}
+
+// Equal reports whether key and other represent the same public key.
+func (key *PublicKeyMLDSA) Equal(other *PublicKeyMLDSA) bool {
+	if other == nil {
+		return false
+	}
+	a, err := createMLDSAPublicKey(key.params.keyType, key.bytes[:key.params.publicKeySize])
+	if err != nil {
+		return false
+	}
+	defer ossl.EVP_PKEY_free(a)
+	b, err := createMLDSAPublicKey(other.params.keyType, other.bytes[:other.params.publicKeySize])
+	if err != nil {
+		return false
+	}
+	defer ossl.EVP_PKEY_free(b)
+	// Equal cannot return an error; treat any failure as inequality.
+	ret, _ := ossl.EVP_PKEY_eq(a, b)
+	return ret == 1
 }
 
 // Parameters returns the parameters associated with this public key.

--- a/openssl/mldsa.go
+++ b/openssl/mldsa.go
@@ -182,17 +182,22 @@ func (key *PrivateKeyMLDSA) Equal(other *PrivateKeyMLDSA) bool {
 	if other == nil {
 		return false
 	}
-	a, err := createMLDSAPrivateKey(key.params.keyType, key.seed[:])
+	a, err := newMLDSAPrivatePkey(key.params.keyType, key.seed[:])
 	if err != nil {
 		return false
 	}
 	defer ossl.EVP_PKEY_free(a)
-	b, err := createMLDSAPrivateKey(other.params.keyType, other.seed[:])
+	b, err := newMLDSAPrivatePkey(other.params.keyType, other.seed[:])
 	if err != nil {
 		return false
 	}
 	defer ossl.EVP_PKEY_free(b)
-	// Equal cannot return an error; treat any failure as inequality.
+	// EVP_PKEY_eq returns 1 if inputs match, 0 if they don't match, -1 if the
+	// key types are different, and -2 if the operation is not supported. We
+	// don't care about the reason, only if they match or aren't confirmed to
+	// match. The error return drains the OpenSSL error queue when the
+	// comparison fails (e.g. on cross-parameter-set inputs), so we keep it
+	// here rather than tagging the binding noerror.
 	ret, _ := ossl.EVP_PKEY_eq(a, b)
 	return ret == 1
 }
@@ -239,7 +244,7 @@ func NewPublicKeyMLDSA(params MLDSAParameters, publicKey []byte) (*PublicKeyMLDS
 		return nil, errors.New("mldsa: invalid public key size")
 	}
 	// Validate by attempting a key import.
-	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	pkey, err := newMLDSAPublicPkey(params.keyType, publicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -259,17 +264,22 @@ func (key *PublicKeyMLDSA) Equal(other *PublicKeyMLDSA) bool {
 	if other == nil {
 		return false
 	}
-	a, err := createMLDSAPublicKey(key.params.keyType, key.bytes[:key.params.publicKeySize])
+	a, err := newMLDSAPublicPkey(key.params.keyType, key.bytes[:key.params.publicKeySize])
 	if err != nil {
 		return false
 	}
 	defer ossl.EVP_PKEY_free(a)
-	b, err := createMLDSAPublicKey(other.params.keyType, other.bytes[:other.params.publicKeySize])
+	b, err := newMLDSAPublicPkey(other.params.keyType, other.bytes[:other.params.publicKeySize])
 	if err != nil {
 		return false
 	}
 	defer ossl.EVP_PKEY_free(b)
-	// Equal cannot return an error; treat any failure as inequality.
+	// EVP_PKEY_eq returns 1 if inputs match, 0 if they don't match, -1 if the
+	// key types are different, and -2 if the operation is not supported. We
+	// don't care about the reason, only if they match or aren't confirmed to
+	// match. The error return drains the OpenSSL error queue when the
+	// comparison fails (e.g. on cross-parameter-set inputs), so we keep it
+	// here rather than tagging the binding noerror.
 	ret, _ := ossl.EVP_PKEY_eq(a, b)
 	return ret == 1
 }
@@ -305,8 +315,8 @@ func generateMLDSASeed(keyType int32, seed []byte) error {
 	return err
 }
 
-// createMLDSAPrivateKey creates an ML-DSA EVP_PKEY from a 32-byte seed.
-func createMLDSAPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
+// newMLDSAPrivatePkey creates an ML-DSA EVP_PKEY from a 32-byte seed.
+func newMLDSAPrivatePkey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 	if len(seed) != privateKeySizeMLDSA {
 		return nil, errors.New("mldsa: invalid seed size")
 	}
@@ -325,8 +335,8 @@ func createMLDSAPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 	return newEvpFromParams(id, ossl.EVP_PKEY_KEYPAIR, params)
 }
 
-// createMLDSAPublicKey creates an ML-DSA EVP_PKEY from encoded public key bytes.
-func createMLDSAPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
+// newMLDSAPublicPkey creates an ML-DSA EVP_PKEY from encoded public key bytes.
+func newMLDSAPublicPkey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
 	bld := newParamBuilder()
 	defer bld.finalize()
 
@@ -344,7 +354,7 @@ func createMLDSAPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, erro
 // mldsaExtractPublicKey derives and copies the encoded public key bytes from
 // a private key seed.
 func mldsaExtractPublicKey(params MLDSAParameters, seed, dst []byte) error {
-	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	pkey, err := newMLDSAPrivatePkey(params.keyType, seed)
 	if err != nil {
 		return err
 	}
@@ -382,7 +392,7 @@ func mldsaSigParams(context string, externalMu bool) (ossl.OSSL_PARAM_PTR, error
 }
 
 func mldsaSign(params MLDSAParameters, seed, message []byte, context string) ([]byte, error) {
-	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	pkey, err := newMLDSAPrivatePkey(params.keyType, seed)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +402,7 @@ func mldsaSign(params MLDSAParameters, seed, message []byte, context string) ([]
 }
 
 func mldsaSignExternalMu(params MLDSAParameters, seed, mu []byte) ([]byte, error) {
-	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	pkey, err := newMLDSAPrivatePkey(params.keyType, seed)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +448,7 @@ func mldsaVerify(params MLDSAParameters, publicKey, message, signature []byte, c
 	if len(signature) != params.signatureSize {
 		return errors.New("mldsa: invalid signature length")
 	}
-	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	pkey, err := newMLDSAPublicPkey(params.keyType, publicKey)
 	if err != nil {
 		return err
 	}
@@ -451,7 +461,7 @@ func mldsaVerifyExternalMu(params MLDSAParameters, publicKey, mu, signature []by
 	if len(signature) != params.signatureSize {
 		return errors.New("mldsa: invalid signature length")
 	}
-	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	pkey, err := newMLDSAPublicPkey(params.keyType, publicKey)
 	if err != nil {
 		return err
 	}

--- a/openssl/mldsa_test.go
+++ b/openssl/mldsa_test.go
@@ -172,6 +172,82 @@ func testMLDSARoundTrip(t *testing.T, params openssl.MLDSAParameters) {
 	}
 }
 
+func TestMLDSAEqual(t *testing.T) {
+	t.Parallel()
+	for _, test := range mldsaParameterTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMLDSAEqual(t, test.params)
+		})
+	}
+}
+
+func testMLDSAEqual(t *testing.T, params openssl.MLDSAParameters) {
+	if !openssl.SupportsMLDSA(params) {
+		t.Skipf("%s not supported on this platform", params)
+	}
+	t.Parallel()
+
+	key, err := openssl.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A key must be equal to itself.
+	if !key.Equal(key) {
+		t.Error("private key is not equal to itself")
+	}
+	if !key.PublicKey().Equal(key.PublicKey()) {
+		t.Error("public key is not equal to itself")
+	}
+	// A key reconstructed from the same seed must compare equal.
+	same, err := openssl.NewPrivateKeyMLDSA(params, key.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !key.Equal(same) {
+		t.Error("private keys from the same seed are not equal")
+	}
+	if !key.PublicKey().Equal(same.PublicKey()) {
+		t.Error("public keys from the same seed are not equal")
+	}
+
+	// An independently generated key must not compare equal.
+	other, err := openssl.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.Equal(other) {
+		t.Error("private keys from different seeds are equal")
+	}
+	if key.PublicKey().Equal(other.PublicKey()) {
+		t.Error("public keys from different seeds are equal")
+	}
+
+	if key.Equal(nil) {
+		t.Error("private key equal to nil")
+	}
+	if key.PublicKey().Equal(nil) {
+		t.Error("public key equal to nil")
+	}
+
+	// Keys of a different parameter set built from the same seed must not
+	// compare equal.
+	for _, otherTest := range mldsaParameterTests {
+		if otherTest.params.String() == params.String() || !openssl.SupportsMLDSA(otherTest.params) {
+			continue
+		}
+		crossParams, err := openssl.NewPrivateKeyMLDSA(otherTest.params, key.Bytes())
+		if err != nil {
+			t.Fatalf("NewPrivateKeyMLDSA(%s): %v", otherTest.params, err)
+		}
+		if key.Equal(crossParams) {
+			t.Errorf("private keys of %s and %s are equal", params, otherTest.params)
+		}
+		if key.PublicKey().Equal(crossParams.PublicKey()) {
+			t.Errorf("public keys of %s and %s are equal", params, otherTest.params)
+		}
+	}
+}
+
 func TestMLDSABadLengths(t *testing.T) {
 	t.Parallel()
 	for _, test := range mldsaParameterTests {


### PR DESCRIPTION
Bind EVP_PKEY_eq in internal/ossl/shims.h (regenerating the cgo bindings) so PrivateKeyMLDSA.Equal and PublicKeyMLDSA.Equal can dispatch to OpenSSL's native key-equality primitive instead of comparing the seed or public-key encoding with crypto/subtle.

Add TestMLDSAEqual covering same-seed, distinct-seed, nil, self-equality, and cross-parameter-set comparisons.