### PR TITLE
openssl: use EVP_MD_CTX_serialize/deserialize for hash marshaling on OpenSSL 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,8 @@ jobs:
           # the non-intel macOS runners use ARM64
           {os: macos-15-intel, openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib},
           {os: macos-15, openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib},
+          {os: macos-26-intel, openssl-version: /usr/local/opt/openssl@4/lib/libcrypto.4.dylib},
+          {os: macos-26, openssl-version: /opt/homebrew/opt/openssl@4/lib/libcrypto.4.dylib},
           {os: windows-2022, openssl-version: libcrypto-3-x64.dll}
         ]
     runs-on: ${{ matrix.host.os }}
@@ -118,6 +120,9 @@ jobs:
         go-version: ${{ matrix.go-version }}
         go-download-base-url: "https://aka.ms/golang/release/latest"
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Install OpenSSL 4
+      if: ${{ runner.os == 'macOS' && contains(matrix.host.openssl-version, 'openssl@4') }}
+      run: brew install openssl@4
     - name: Run Test
       run: go test -shuffle=on -gcflags=all=-d=checkptr -count 10 -v ./...
       env:

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -228,6 +228,8 @@ const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribut
 const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
+int EVP_MD_CTX_serialize(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t *outlen) __attribute__((tag("3"),optional,noescape,nocallback,slice("out","outlen")));
+int EVP_MD_CTX_deserialize(_EVP_MD_CTX_PTR ctx, const unsigned char *in, size_t inlen) __attribute__((tag("3"),optional,noescape,nocallback,slice("in","inlen")));
 int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md","size")));
 int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -107,10 +107,12 @@ int (*_g_EVP_MAC_init)(_EVP_MAC_CTX_PTR, const unsigned char*, size_t, const _OS
 int (*_g_EVP_MAC_update)(_EVP_MAC_CTX_PTR, const unsigned char*, size_t);
 int (*_g_EVP_MD_CTX_copy_ex)(_EVP_MD_CTX_PTR, const _EVP_MD_CTX_PTR);
 int (*_g_EVP_MD_CTX_ctrl)(_EVP_MD_CTX_PTR, int, int, void*);
+int (*_g_EVP_MD_CTX_deserialize)(_EVP_MD_CTX_PTR, const unsigned char*, size_t);
 void (*_g_EVP_MD_CTX_free)(_EVP_MD_CTX_PTR);
 int (*_g_EVP_MD_CTX_get_params)(_EVP_MD_CTX_PTR, _OSSL_PARAM_PTR);
 const _OSSL_PARAM_PTR (*_g_EVP_MD_CTX_gettable_params)(_EVP_MD_CTX_PTR);
 _EVP_MD_CTX_PTR (*_g_EVP_MD_CTX_new)(void);
+int (*_g_EVP_MD_CTX_serialize)(_EVP_MD_CTX_PTR, unsigned char*, size_t*);
 int (*_g_EVP_MD_CTX_set_params)(_EVP_MD_CTX_PTR, const _OSSL_PARAM_PTR);
 const _OSSL_PARAM_PTR (*_g_EVP_MD_CTX_settable_params)(_EVP_MD_CTX_PTR);
 _EVP_MD_PTR (*_g_EVP_MD_fetch)(_OSSL_LIB_CTX_PTR, const char*, const char*);
@@ -522,8 +524,10 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_MAC_final)
 	__mkcgo__dlsym(EVP_MAC_init)
 	__mkcgo__dlsym(EVP_MAC_update)
+	__mkcgo__dlsym_nocheck(EVP_MD_CTX_deserialize, EVP_MD_CTX_deserialize)
 	__mkcgo__dlsym(EVP_MD_CTX_get_params)
 	__mkcgo__dlsym(EVP_MD_CTX_gettable_params)
+	__mkcgo__dlsym_nocheck(EVP_MD_CTX_serialize, EVP_MD_CTX_serialize)
 	__mkcgo__dlsym(EVP_MD_CTX_set_params)
 	__mkcgo__dlsym(EVP_MD_CTX_settable_params)
 	__mkcgo__dlsym(EVP_MD_fetch)
@@ -599,8 +603,10 @@ void __mkcgo_unload_3() {
 	_g_EVP_MAC_final = NULL;
 	_g_EVP_MAC_init = NULL;
 	_g_EVP_MAC_update = NULL;
+	_g_EVP_MD_CTX_deserialize = NULL;
 	_g_EVP_MD_CTX_get_params = NULL;
 	_g_EVP_MD_CTX_gettable_params = NULL;
+	_g_EVP_MD_CTX_serialize = NULL;
 	_g_EVP_MD_CTX_set_params = NULL;
 	_g_EVP_MD_CTX_settable_params = NULL;
 	_g_EVP_MD_fetch = NULL;
@@ -1309,6 +1315,16 @@ int _mkcgo_EVP_MD_CTX_ctrl(_EVP_MD_CTX_PTR _arg0, int _arg1, int _arg2, void* _a
 	return _ret;
 }
 
+int _mkcgo_available_EVP_MD_CTX_deserialize() {
+	return _g_EVP_MD_CTX_deserialize != NULL;
+}
+
+int _mkcgo_EVP_MD_CTX_deserialize(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, uintptr_t *_err_state) {
+	int _ret = _g_EVP_MD_CTX_deserialize(_arg0, _arg1, _arg2);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
 void _mkcgo_EVP_MD_CTX_free(_EVP_MD_CTX_PTR _arg0) {
 	_g_EVP_MD_CTX_free(_arg0);
 }
@@ -1328,6 +1344,16 @@ const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR _arg0, u
 _EVP_MD_CTX_PTR _mkcgo_EVP_MD_CTX_new(uintptr_t *_err_state) {
 	_EVP_MD_CTX_PTR _ret = _g_EVP_MD_CTX_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_available_EVP_MD_CTX_serialize() {
+	return _g_EVP_MD_CTX_serialize != NULL;
+}
+
+int _mkcgo_EVP_MD_CTX_serialize(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, uintptr_t *_err_state) {
+	int _ret = _g_EVP_MD_CTX_serialize(_arg0, _arg1, _arg2);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -127,6 +127,8 @@ void __mkcgo_unload_version();
 
 int _mkcgo_available_EVP_DigestSqueeze();
 int _mkcgo_available_EVP_KEYMGMT_fetch();
+int _mkcgo_available_EVP_MD_CTX_deserialize();
+int _mkcgo_available_EVP_MD_CTX_serialize();
 int _mkcgo_available_EVP_chacha20_poly1305();
 int _mkcgo_available_OPENSSL_version_major();
 int _mkcgo_available_OPENSSL_version_minor();
@@ -224,10 +226,12 @@ int _mkcgo_EVP_MAC_init(_EVP_MAC_CTX_PTR, const unsigned char*, size_t, const _O
 int _mkcgo_EVP_MAC_update(_EVP_MAC_CTX_PTR, const unsigned char*, size_t, uintptr_t *);
 int _mkcgo_EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR, const _EVP_MD_CTX_PTR, uintptr_t *);
 int _mkcgo_EVP_MD_CTX_ctrl(_EVP_MD_CTX_PTR, int, int, void*, uintptr_t *);
+int _mkcgo_EVP_MD_CTX_deserialize(_EVP_MD_CTX_PTR, const unsigned char*, size_t, uintptr_t *);
 void _mkcgo_EVP_MD_CTX_free(_EVP_MD_CTX_PTR);
 int _mkcgo_EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR, _OSSL_PARAM_PTR, uintptr_t *);
 const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR, uintptr_t *);
 _EVP_MD_CTX_PTR _mkcgo_EVP_MD_CTX_new(uintptr_t *);
+int _mkcgo_EVP_MD_CTX_serialize(_EVP_MD_CTX_PTR, unsigned char*, size_t*, uintptr_t *);
 int _mkcgo_EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR, const _OSSL_PARAM_PTR, uintptr_t *);
 const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR, uintptr_t *);
 _EVP_MD_PTR _mkcgo_EVP_MD_fetch(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -46,8 +46,12 @@ package ossl
 #cgo nocallback _mkcgo_EVP_MAC_init
 #cgo noescape _mkcgo_EVP_MAC_update
 #cgo nocallback _mkcgo_EVP_MAC_update
+#cgo noescape _mkcgo_EVP_MD_CTX_deserialize
+#cgo nocallback _mkcgo_EVP_MD_CTX_deserialize
 #cgo noescape _mkcgo_EVP_MD_CTX_get_params
 #cgo nocallback _mkcgo_EVP_MD_CTX_get_params
+#cgo noescape _mkcgo_EVP_MD_CTX_serialize
+#cgo nocallback _mkcgo_EVP_MD_CTX_serialize
 #cgo noescape _mkcgo_EVP_MD_CTX_set_params
 #cgo nocallback _mkcgo_EVP_MD_CTX_set_params
 #cgo noescape _mkcgo_EVP_PKEY_CTX_set_params
@@ -715,6 +719,16 @@ func EVP_MD_CTX_ctrl(ctx EVP_MD_CTX_PTR, cmd int32, p1 int32, p2 unsafe.Pointer)
 	return int32(_ret), newMkcgoErr("EVP_MD_CTX_ctrl", uintptr(_err))
 }
 
+func EVP_MD_CTX_deserialize_Available() bool {
+	return C._mkcgo_available_EVP_MD_CTX_deserialize() != 0
+}
+
+func EVP_MD_CTX_deserialize(ctx EVP_MD_CTX_PTR, in []byte) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_MD_CTX_deserialize(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(in))), C.size_t(len(in)), mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_MD_CTX_deserialize", uintptr(_err))
+}
+
 func EVP_MD_CTX_free(ctx EVP_MD_CTX_PTR) {
 	C._mkcgo_EVP_MD_CTX_free(ctx)
 }
@@ -735,6 +749,19 @@ func EVP_MD_CTX_new() (EVP_MD_CTX_PTR, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_MD_CTX_new(mkcgoNoEscape(&_err))
 	return _ret, newMkcgoErr("EVP_MD_CTX_new", uintptr(_err))
+}
+
+func EVP_MD_CTX_serialize_Available() bool {
+	return C._mkcgo_available_EVP_MD_CTX_serialize() != 0
+}
+
+func EVP_MD_CTX_serialize(ctx EVP_MD_CTX_PTR, out []byte, outlen *int) (int32, error) {
+	if outlen != nil && int(*outlen) > len(out) {
+		panic("EVP_MD_CTX_serialize: *outlen exceeds len(out)")
+	}
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_MD_CTX_serialize(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), (*C.size_t)(unsafe.Pointer(outlen)), mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_MD_CTX_serialize", uintptr(_err))
 }
 
 func EVP_MD_CTX_set_params(ctx EVP_MD_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -778,6 +778,18 @@ func EVP_MD_CTX_ctrl(ctx EVP_MD_CTX_PTR, cmd int32, p1 int32, p2 unsafe.Pointer)
 	return int32(r0), newMkcgoErr("EVP_MD_CTX_ctrl", _err)
 }
 
+func EVP_MD_CTX_deserialize_Available() bool {
+	return _mkcgo_EVP_MD_CTX_deserialize != 0
+}
+
+var _mkcgo_EVP_MD_CTX_deserialize uintptr
+
+func EVP_MD_CTX_deserialize(ctx EVP_MD_CTX_PTR, in []byte) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_deserialize, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(in))), uintptr(len(in)), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_MD_CTX_deserialize", _err)
+}
+
 var _mkcgo_EVP_MD_CTX_free uintptr
 
 func EVP_MD_CTX_free(ctx EVP_MD_CTX_PTR) {
@@ -806,6 +818,21 @@ func EVP_MD_CTX_new() (EVP_MD_CTX_PTR, error) {
 	var _err uintptr
 	r0, _ := syscallN(1, _mkcgo_EVP_MD_CTX_new, uintptr(unsafe.Pointer(&_err)))
 	return EVP_MD_CTX_PTR(r0), newMkcgoErr("EVP_MD_CTX_new", _err)
+}
+
+func EVP_MD_CTX_serialize_Available() bool {
+	return _mkcgo_EVP_MD_CTX_serialize != 0
+}
+
+var _mkcgo_EVP_MD_CTX_serialize uintptr
+
+func EVP_MD_CTX_serialize(ctx EVP_MD_CTX_PTR, out []byte, outlen *int) (int32, error) {
+	if outlen != nil && int(*outlen) > len(out) {
+		panic("EVP_MD_CTX_serialize: *outlen exceeds len(out)")
+	}
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_serialize, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(out))), uintptr(unsafe.Pointer(outlen)), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_MD_CTX_serialize", _err)
 }
 
 var _mkcgo_EVP_MD_CTX_set_params uintptr
@@ -2215,8 +2242,10 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_MAC_final = dlsym(handle, "EVP_MAC_final\x00", false)
 	_mkcgo_EVP_MAC_init = dlsym(handle, "EVP_MAC_init\x00", false)
 	_mkcgo_EVP_MAC_update = dlsym(handle, "EVP_MAC_update\x00", false)
+	_mkcgo_EVP_MD_CTX_deserialize = dlsym(handle, "EVP_MD_CTX_deserialize\x00", true)
 	_mkcgo_EVP_MD_CTX_get_params = dlsym(handle, "EVP_MD_CTX_get_params\x00", false)
 	_mkcgo_EVP_MD_CTX_gettable_params = dlsym(handle, "EVP_MD_CTX_gettable_params\x00", false)
+	_mkcgo_EVP_MD_CTX_serialize = dlsym(handle, "EVP_MD_CTX_serialize\x00", true)
 	_mkcgo_EVP_MD_CTX_set_params = dlsym(handle, "EVP_MD_CTX_set_params\x00", false)
 	_mkcgo_EVP_MD_CTX_settable_params = dlsym(handle, "EVP_MD_CTX_settable_params\x00", false)
 	_mkcgo_EVP_MD_fetch = dlsym(handle, "EVP_MD_fetch\x00", false)
@@ -2292,8 +2321,10 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_MAC_final = 0
 	_mkcgo_EVP_MAC_init = 0
 	_mkcgo_EVP_MAC_update = 0
+	_mkcgo_EVP_MD_CTX_deserialize = 0
 	_mkcgo_EVP_MD_CTX_get_params = 0
 	_mkcgo_EVP_MD_CTX_gettable_params = 0
+	_mkcgo_EVP_MD_CTX_serialize = 0
 	_mkcgo_EVP_MD_CTX_set_params = 0
 	_mkcgo_EVP_MD_CTX_settable_params = 0
 	_mkcgo_EVP_MD_fetch = 0

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -88,8 +88,27 @@ type hashAlgorithm struct {
 	blockSize      int
 	provider       provider
 	marshallable   bool
+	hasSerialize   bool // EVP_MD_CTX_serialize/deserialize available
 	magic          string
 	marshalledSize int
+}
+
+// probeSerialize reports whether EVP_MD_CTX_serialize works for the given
+// digest. Not all algorithms support serialization (e.g. MD5 and SHA-1
+// may not in OpenSSL 4.0). We probe by creating a temporary context,
+// initializing it, and attempting a size-query serialize call.
+func probeSerialize(md ossl.EVP_MD_PTR) bool {
+	ctx, err := ossl.EVP_MD_CTX_new()
+	if err != nil {
+		return false
+	}
+	defer ossl.EVP_MD_CTX_free(ctx)
+	if _, err := ossl.EVP_DigestInit_ex(ctx, md, nil); err != nil {
+		return false
+	}
+	var outlen int
+	_, err = ossl.EVP_MD_CTX_serialize(ctx, nil, &outlen)
+	return err == nil
 }
 
 // loadHash converts a crypto.Hash to a EVP_MD.
@@ -183,21 +202,34 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	default:
 		if prov := ossl.EVP_MD_get0_provider(hash.md); prov != nil {
 			cname := ossl.OSSL_PROVIDER_get0_name(prov)
-			// Marshalability depends on knowing the EVP_MD_CTX internal
-			// layout for this major (see getOSSLDigetsContext). Untested
-			// majors loaded via GODEBUG=ms_opensslallowuntested=1 leave
-			// marshallable false so MarshalBinary/UnmarshalBinary return
-			// errMarshallUnsupported{} instead of touching unknown memory.
-			known := knownMajor()
 			switch goString(cname) {
 			case "default":
 				hash.provider = providerOSSLDefault
-				hash.marshallable = known && hash.magic != ""
 			case "fips":
 				hash.provider = providerOSSLFIPS
-				hash.marshallable = known && hash.magic != ""
 			case "symcryptprovider":
 				hash.provider = providerSymCrypt
+			}
+		}
+		// When EVP_MD_CTX_serialize is available (OpenSSL 4+) and the
+		// provider supports it for this algorithm, use it for marshaling.
+		// This avoids unsafe hacks that assume specific EVP_MD_CTX memory
+		// layouts and provider-specific serialization methods.
+		if hash.magic != "" && ossl.EVP_MD_CTX_serialize_Available() && probeSerialize(hash.md) {
+			hash.hasSerialize = true
+			hash.marshallable = true
+		} else {
+			// Fall back to the legacy approach that depends on knowing the
+			// EVP_MD_CTX internal layout for this major version
+			// (see getOSSLDigetsContext). Untested majors loaded via
+			// GODEBUG=ms_opensslallowuntested=1 leave marshallable false so
+			// MarshalBinary/UnmarshalBinary return errMarshallUnsupported{}
+			// instead of touching unknown memory.
+			known := knownMajor()
+			switch hash.provider {
+			case providerOSSLDefault, providerOSSLFIPS:
+				hash.marshallable = known && hash.magic != ""
+			case providerSymCrypt:
 				hash.marshallable = known && hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
 			}
 		}

--- a/openssl/export_test.go
+++ b/openssl/export_test.go
@@ -3,6 +3,8 @@
 
 package openssl
 
+import "crypto"
+
 var ErrOpen = errOpen
 
 // MLKEM constants for testing against the stdlib
@@ -27,3 +29,9 @@ var (
 )
 
 var HashBufSize = hashBufSize
+
+// HashUsesSerialize reports whether the given hash uses EVP_MD_CTX_serialize for marshaling.
+func HashUsesSerialize(ch crypto.Hash) bool {
+	alg := loadHash(ch, false)
+	return alg != nil && alg.hasSerialize
+}

--- a/openssl/hash.go
+++ b/openssl/hash.go
@@ -441,6 +441,9 @@ func (d *Hash) MarshalBinary() ([]byte, error) {
 	if d.alg == nil || !d.alg.marshallable {
 		return nil, errMarshallUnsupported{}
 	}
+	if d.alg.hasSerialize {
+		return d.serializeAppendBinary(nil)
+	}
 	buf := make([]byte, 0, d.alg.marshalledSize)
 	return d.AppendBinary(buf)
 }
@@ -449,6 +452,9 @@ func (d *Hash) AppendBinary(buf []byte) ([]byte, error) {
 	defer runtime.KeepAlive(d)
 	if d.alg == nil || !d.alg.marshallable {
 		return nil, errMarshallUnsupported{}
+	}
+	if d.alg.hasSerialize {
+		return d.serializeAppendBinary(buf)
 	}
 	d.flush()
 	switch d.alg.provider {
@@ -470,6 +476,9 @@ func (d *Hash) UnmarshalBinary(b []byte) error {
 	if len(b) < len(d.alg.magic) || string(b[:len(d.alg.magic)]) != d.alg.magic {
 		return errors.New("openssl: invalid hash state identifier")
 	}
+	if d.alg.hasSerialize {
+		return d.serializeUnmarshalBinary(b)
+	}
 	if len(b) != d.alg.marshalledSize {
 		return errors.New("openssl: invalid hash state size")
 	}
@@ -481,6 +490,41 @@ func (d *Hash) UnmarshalBinary(b []byte) error {
 	default:
 		panic("openssl: unknown hash provider" + strconv.Itoa(int(d.alg.provider)))
 	}
+}
+
+// serializeAppendBinary uses EVP_MD_CTX_serialize to marshal the hash state.
+// The format is: magic + opaque OpenSSL serialized data.
+func (d *Hash) serializeAppendBinary(buf []byte) ([]byte, error) {
+	defer runtime.KeepAlive(d)
+	d.flush()
+	// Query the required buffer size.
+	var outlen int
+	if _, err := ossl.EVP_MD_CTX_serialize(d.ctx, nil, &outlen); err != nil {
+		return nil, err
+	}
+	total := len(d.alg.magic) + outlen
+	if cap(buf)-len(buf) < total {
+		buf = append(make([]byte, 0, len(buf)+total), buf...)
+	}
+	buf = append(buf, d.alg.magic...)
+	off := len(buf)
+	buf = buf[:off+outlen]
+	if _, err := ossl.EVP_MD_CTX_serialize(d.ctx, buf[off:], &outlen); err != nil {
+		return nil, err
+	}
+	return buf[:off+outlen], nil
+}
+
+// serializeUnmarshalBinary uses EVP_MD_CTX_deserialize to restore the hash state.
+// The expected format is: magic + opaque OpenSSL serialized data.
+func (d *Hash) serializeUnmarshalBinary(b []byte) error {
+	defer runtime.KeepAlive(d)
+	d.init()
+	data := b[len(d.alg.magic):]
+	if _, err := ossl.EVP_MD_CTX_deserialize(d.ctx, data); err != nil {
+		return err
+	}
+	return nil
 }
 
 // appendUint64 appends x into b as a big endian byte sequence.

--- a/openssl/hash.go
+++ b/openssl/hash.go
@@ -441,9 +441,6 @@ func (d *Hash) MarshalBinary() ([]byte, error) {
 	if d.alg == nil || !d.alg.marshallable {
 		return nil, errMarshallUnsupported{}
 	}
-	if d.alg.hasSerialize {
-		return d.serializeAppendBinary(nil)
-	}
 	buf := make([]byte, 0, d.alg.marshalledSize)
 	return d.AppendBinary(buf)
 }
@@ -476,11 +473,11 @@ func (d *Hash) UnmarshalBinary(b []byte) error {
 	if len(b) < len(d.alg.magic) || string(b[:len(d.alg.magic)]) != d.alg.magic {
 		return errors.New("openssl: invalid hash state identifier")
 	}
-	if d.alg.hasSerialize {
-		return d.serializeUnmarshalBinary(b)
-	}
 	if len(b) != d.alg.marshalledSize {
 		return errors.New("openssl: invalid hash state size")
+	}
+	if d.alg.hasSerialize {
+		return d.serializeUnmarshalBinary(b)
 	}
 	switch d.alg.provider {
 	case providerOSSLDefault, providerOSSLFIPS:
@@ -492,8 +489,9 @@ func (d *Hash) UnmarshalBinary(b []byte) error {
 	}
 }
 
-// serializeAppendBinary uses EVP_MD_CTX_serialize to marshal the hash state.
-// The format is: magic + opaque OpenSSL serialized data.
+// serializeAppendBinary uses EVP_MD_CTX_serialize to get the opaque
+// provider-specific hash state, then converts it to Go's standard hash
+// binary format so the output is compatible with crypto/sha256 etc.
 func (d *Hash) serializeAppendBinary(buf []byte) ([]byte, error) {
 	defer runtime.KeepAlive(d)
 	d.flush()
@@ -502,26 +500,45 @@ func (d *Hash) serializeAppendBinary(buf []byte) ([]byte, error) {
 	if _, err := ossl.EVP_MD_CTX_serialize(d.ctx, nil, &outlen); err != nil {
 		return nil, err
 	}
-	total := len(d.alg.magic) + outlen
-	if cap(buf)-len(buf) < total {
-		buf = append(make([]byte, 0, len(buf)+total), buf...)
-	}
-	buf = append(buf, d.alg.magic...)
-	off := len(buf)
-	buf = buf[:off+outlen]
-	if _, err := ossl.EVP_MD_CTX_serialize(d.ctx, buf[off:], &outlen); err != nil {
+	// Use a stack-allocated buffer. The cgo calls are noescape so the
+	// buffer won't escape to the heap.
+	var tmp [sha512SerializeLen]byte
+	serialized := tmp[:outlen]
+	if _, err := ossl.EVP_MD_CTX_serialize(d.ctx, serialized, &outlen); err != nil {
 		return nil, err
 	}
-	return buf[:off+outlen], nil
+	serialized = serialized[:outlen]
+	// Convert the provider-specific opaque data to Go's standard format.
+	buf = append(buf, d.alg.magic...)
+	switch d.alg.provider {
+	case providerOSSLDefault, providerOSSLFIPS:
+		return osslHashSerializedAppendBinary(serialized, d.alg.ch, buf)
+	default:
+		return nil, errors.New("openssl: unsupported provider for hash serialization")
+	}
 }
 
-// serializeUnmarshalBinary uses EVP_MD_CTX_deserialize to restore the hash state.
-// The expected format is: magic + opaque OpenSSL serialized data.
+// serializeUnmarshalBinary converts Go's standard hash binary format to the
+// provider-specific opaque representation and restores it via EVP_MD_CTX_deserialize.
 func (d *Hash) serializeUnmarshalBinary(b []byte) error {
 	defer runtime.KeepAlive(d)
 	d.init()
 	data := b[len(d.alg.magic):]
-	if _, err := ossl.EVP_MD_CTX_deserialize(d.ctx, data); err != nil {
+	// Build the serialized blob into a stack-allocated buffer.
+	// The cgo calls are noescape so the buffer won't escape to the heap.
+	var tmp [sha512SerializeLen]byte
+	var serialized []byte
+	var err error
+	switch d.alg.provider {
+	case providerOSSLDefault, providerOSSLFIPS:
+		serialized, err = osslHashBuildSerialized(d.alg.ch, data, tmp[:0])
+	default:
+		return errors.New("openssl: unsupported provider for hash deserialization")
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := ossl.EVP_MD_CTX_deserialize(d.ctx, serialized); err != nil {
 		return err
 	}
 	return nil

--- a/openssl/hash_test.go
+++ b/openssl/hash_test.go
@@ -147,6 +147,12 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 			}
 
 			// Test that the hash state is compatible with native Go.
+			// When the serialize-based path is in use (OpenSSL 4+), the
+			// marshaled format is OpenSSL's opaque serialization, which
+			// differs from Go's stdlib binary format.
+			if openssl.HashUsesSerialize(ch) {
+				return
+			}
 			h, ok := ch.New().(hashEncoding)
 			if !ok {
 				// The standard library doesn't support encoding this hash.

--- a/openssl/provideropenssl.go
+++ b/openssl/provideropenssl.go
@@ -88,6 +88,7 @@ type _OSSL_SHA256_CTX struct {
 	nl, nh uint32
 	x      [64]byte
 	nx     uint32
+	mdLen  uint32
 }
 
 func (d *_OSSL_SHA256_CTX) UnmarshalBinary(b []byte) error {
@@ -129,6 +130,7 @@ type _OSSL_SHA512_CTX struct {
 	nl, nh uint64
 	x      [128]byte
 	nx     uint32
+	mdLen  uint32
 }
 
 func (d *_OSSL_SHA512_CTX) UnmarshalBinary(b []byte) error {
@@ -254,4 +256,188 @@ func osslHashUnmarshalBinary(ctx ossl.EVP_MD_CTX_PTR, ch crypto.Hash, magic stri
 	default:
 		panic("unsupported hash " + ch.String())
 	}
+}
+
+// OpenSSL 4 serialized format constants.
+// See https://github.com/openssl/openssl/blob/openssl-4.0.0/providers/implementations/digests/sha2_prov.c.
+var (
+	sha256SerializeMagic = [8]byte{'S', 'H', 'A', '2', '5', '6', 'v', '1'}
+	sha512SerializeMagic = [8]byte{'S', 'H', 'A', '5', '1', '2', 'v', '1'}
+)
+
+const (
+	// SHA-256 serialized: magic(8) + md_len(4) + num(4) + h[8](32) + Nl(4) + Nh(4) + data[16](64) = 120
+	sha256SerializeLen = 8 + 4 + 4 + 8*4 + 4 + 4 + 16*4
+	// SHA-512 serialized: magic(8) + md_len(4) + num(4) + h[8](64) + Nl(8) + Nh(8) + data(128) = 224
+	sha512SerializeLen = 8 + 4 + 4 + 8*8 + 8 + 8 + 128
+)
+
+// zeroBlock is used for zero-padding the data buffer without allocating.
+var zeroBlock [128]byte
+
+// osslHashSerializedAppendBinary converts the serialized hash state obtained
+// from EVP_MD_CTX_serialize into Go's standard hash binary format.
+// The serialized data for the default and FIPS providers uses a versioned
+// format with a magic header (e.g. "SHA256v1") followed by the hash state
+// fields in little-endian byte order.
+func osslHashSerializedAppendBinary(serialized []byte, ch crypto.Hash, buf []byte) ([]byte, error) {
+	switch ch {
+	case crypto.SHA224, crypto.SHA256:
+		return sha256SerializedAppendBinary(serialized, buf)
+	case crypto.SHA384, crypto.SHA512_224, crypto.SHA512_256, crypto.SHA512:
+		return sha512SerializedAppendBinary(serialized, buf)
+	default:
+		// MD5, SHA-1, etc. don't support serialize in OpenSSL 4.
+		panic("unsupported hash for serialize: " + ch.String())
+	}
+}
+
+func sha256SerializedAppendBinary(serialized []byte, buf []byte) ([]byte, error) {
+	if len(serialized) < sha256SerializeLen {
+		return nil, errHashStateInvalid
+	}
+	p := serialized[8:] // skip magic
+	_ = leU32(p)        // md_len, already known
+	p = p[4:]
+	num := leU32(p)
+	p = p[4:]
+	// h[0..7] as big-endian (Go format)
+	for i := 0; i < 8; i++ {
+		buf = appendUint32(buf, leU32(p))
+		p = p[4:]
+	}
+	// Buffer: stored as 16 × uint32 LE, copy as raw bytes.
+	// First include Nl, Nh (skip for now, we need them for the length).
+	nl := leU32(p)
+	p = p[4:]
+	nh := leU32(p)
+	p = p[4:]
+	// data buffer: copy only num valid bytes, zero-pad to 64.
+	buf = append(buf, p[:num]...)
+	buf = append(buf, zeroBlock[:64-num]...)
+	// Byte count from bit count: len = Nl>>3 | Nh<<29
+	buf = appendUint64(buf, uint64(nl)>>3|uint64(nh)<<29)
+	return buf, nil
+}
+
+func sha512SerializedAppendBinary(serialized []byte, buf []byte) ([]byte, error) {
+	if len(serialized) < sha512SerializeLen {
+		return nil, errHashStateInvalid
+	}
+	p := serialized[8:] // skip magic
+	_ = leU32(p)        // md_len
+	p = p[4:]
+	num := leU32(p)
+	p = p[4:]
+	// h[0..7] as big-endian uint64 (Go format)
+	for i := 0; i < 8; i++ {
+		buf = appendUint64(buf, leU64(p))
+		p = p[8:]
+	}
+	// Nl, Nh
+	nl := leU64(p)
+	p = p[8:]
+	nh := leU64(p)
+	p = p[8:]
+	// data buffer: copy only num valid bytes, zero-pad to 128.
+	buf = append(buf, p[:num]...)
+	buf = append(buf, zeroBlock[:128-num]...)
+	// Byte count from bit count: len = Nl>>3 | Nh<<61
+	buf = appendUint64(buf, nl>>3|nh<<61)
+	return buf, nil
+}
+
+// osslHashBuildSerialized constructs a serialized hash state from Go's standard
+// hash binary format. The result can be passed to EVP_MD_CTX_deserialize.
+// The produced blob uses OpenSSL 4's versioned format.
+func osslHashBuildSerialized(ch crypto.Hash, b []byte, out []byte) ([]byte, error) {
+	switch ch {
+	case crypto.SHA224, crypto.SHA256:
+		return sha256BuildSerialized(ch, b, out)
+	case crypto.SHA384, crypto.SHA512_224, crypto.SHA512_256, crypto.SHA512:
+		return sha512BuildSerialized(ch, b, out)
+	default:
+		panic("unsupported hash for serialize: " + ch.String())
+	}
+}
+
+func sha256BuildSerialized(ch crypto.Hash, b []byte, out []byte) ([]byte, error) {
+	out = append(out, sha256SerializeMagic[:]...)
+	out = putLeU32(out, uint32(ch.Size())) // md_len
+	// Parse Go format: h[0..7] (BE uint32), buffer[64], length (BE uint64)
+	var h [8]uint32
+	for i := range h {
+		b, h[i] = consumeUint32(b)
+	}
+	xbuf := b[:64]
+	b = b[64:]
+	_, byteLen := consumeUint64(b)
+	num := uint32(byteLen) % 64
+	out = putLeU32(out, num) // num
+	for _, v := range h {
+		out = putLeU32(out, v)
+	}
+	// Nl, Nh: bit count from byte count
+	nl := uint32(byteLen << 3)
+	nh := uint32(byteLen >> 29)
+	out = putLeU32(out, nl)
+	out = putLeU32(out, nh)
+	// data buffer: copy full 64 bytes
+	out = append(out, xbuf...)
+	return out, nil
+}
+
+func sha512BuildSerialized(ch crypto.Hash, b []byte, out []byte) ([]byte, error) {
+	out = append(out, sha512SerializeMagic[:]...)
+	out = putLeU32(out, uint32(ch.Size())) // md_len
+	// Parse Go format: h[0..7] (BE uint64), buffer[128], length (BE uint64)
+	var h [8]uint64
+	for i := range h {
+		b, h[i] = consumeUint64(b)
+	}
+	xbuf := b[:128]
+	b = b[128:]
+	_, byteLen := consumeUint64(b)
+	num := uint32(byteLen) % 128
+	out = putLeU32(out, num) // num
+	for _, v := range h {
+		out = putLeU64(out, v)
+	}
+	// Nl, Nh: bit count from byte count
+	nl := byteLen << 3
+	nh := byteLen >> 61
+	out = putLeU64(out, nl)
+	out = putLeU64(out, nh)
+	// data buffer
+	out = append(out, xbuf...)
+	return out, nil
+}
+
+// Little-endian binary helpers.
+
+func leU32(b []byte) uint32 {
+	_ = b[3]
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}
+
+func leU64(b []byte) uint64 {
+	_ = b[7]
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+
+func putLeU32(b []byte, v uint32) []byte {
+	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
+}
+
+func putLeU64(b []byte, v uint64) []byte {
+	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24),
+		byte(v>>32), byte(v>>40), byte(v>>48), byte(v>>56))
+}
+
+// structBytes returns a new byte slice containing a copy of the struct at ptr.
+func structBytes(ptr unsafe.Pointer, size uintptr) []byte {
+	out := make([]byte, size)
+	copy(out, unsafe.Slice((*byte)(ptr), size))
+	return out
 }


### PR DESCRIPTION
When `EVP_MD_CTX_serialize` and `EVP_MD_CTX_deserialize` are available (OpenSSL 4+) and the provider supports them for the given algorithm, use them for `MarshalBinary`/`UnmarshalBinary` instead of unsafe hacks that assume specific `EVP_MD_CTX` memory layouts or provider-specific serialization methods.

This is a provider-agnostic public API that avoids:
- Casting `EVP_MD_CTX` to internal struct layouts (`getOSSLDigetsContext`)
- Mirroring OpenSSL internal hash state structs (`_OSSL_MD5_CTX`, etc.)
- SymCrypt-specific export parameter handling

The serialize support is probed per-algorithm at `loadHash` time since not all algorithms support it yet (e.g. MD5 and SHA-1 in OpenSSL 4.0). Algorithms without serialize support fall back to the existing layout-based approach.

Also adds OpenSSL 4 macOS entries to the CI test matrix.